### PR TITLE
Error when compiling on 64bit Arch Linux

### DIFF
--- a/ptrace.c
+++ b/ptrace.c
@@ -1,7 +1,7 @@
 #include <sys/ptrace.h>
+#include <sys/types.h>
 #include <sys/user.h>
 #include <sys/wait.h>
-#include <sys/types.h>
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
Thanks for writing this useful program. When I tried to compile it on, make gave me the following error:

% make
cc -Wall -Werror -D_GNU_SOURCE -g   -c -o reptyr.o reptyr.c
cc -Wall -Werror -D_GNU_SOURCE -g   -c -o ptrace.o ptrace.c
In file included from ptrace.c:2:0:
/usr/include/sys/user.h:32:3: error: expected specifier-qualifier-list before ‘__uint16_t’
make: **\* [ptrace.o] Error 1

The solution was to include <sys/types.h> before <sys/user.h>, as in the attached commit.
