### PR TITLE
Use obscure make syntax to make Debian packaging easier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CFLAGS=-Wall -Werror -D_GNU_SOURCE -g
+override CFLAGS+=-Wall -Werror -D_GNU_SOURCE -g
 OBJS=reptyr.o ptrace.o attach.o
 
 PREFIX=/usr/local


### PR DESCRIPTION
Debian wants to be able to inject a standard set of buildflags, some based on policy and some based on user input (for instance, -O2, unless DEB_BUILD_OPTIONS is set to noopt)

This patch lets me run "make CFLAGS=foo" and have that foo append, rather than override, the CFLAGS in your Makefile
