### PR TITLE
add possibility to override PREFIX in Makefile from command line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 override CFLAGS+=-Wall -Werror -D_GNU_SOURCE -g
 OBJS=reptyr.o ptrace.o attach.o
 
-PREFIX=/usr/local
+PREFIX?=/usr/local
 
 all: reptyr
 


### PR DESCRIPTION
Hi,

this simple change makes it possible to install reptyer to a different directory without modifying  the Makefile. 
