### PR TITLE
Return more correct value for get_pgroup

### DIFF
--- a/attach.c
+++ b/attach.c
@@ -344,8 +344,8 @@ int check_pgroup(pid_t target) {
 
     pg = getpgid(target);
     if (pg < 0) {
-        error("Unable to get pgid (does process %d exist?)", (int)target);
-        return pg;
+        error("Unable to get pgid for pid %d", (int)target);
+        return errno;
     }
 
     if ((dir = opendir("/proc/")) == NULL)


### PR DESCRIPTION
Down the line, the return value of get_pgroup is passed to `strerror`. As such, it should probably be a proper errno value rather than -1. In cases where someone tries to reparent a non-existant pid, this changes the error message from:

```
[-] Unable to get pgid (does process 26197 exist?)
Unable to attach to pid 26197: Unknown error -1
```

to

```
[-] Unable to get pgid for pid 26197
Unable to attach to pid 26197: No such process
```

which seems more correct.
