### PR TITLE
Retry tcsetattr on EINTR and report failure

### DIFF
--- a/reptyr.c
+++ b/reptyr.c
@@ -278,7 +278,11 @@ int main(int argc, char **argv) {
     sigaction(SIGWINCH, &act, NULL);
     resize_pty(pty);
     do_proxy(pty);
-    tcsetattr(0, TCSANOW, &saved_termios);
+    do {
+        errno = 0;
+        if (tcsetattr(0, TCSANOW, &saved_termios) && errno != EINTR)
+            die("Unable to tcsetattr: %m");
+    } while (errno == EINTR);
 
     return 0;
 }


### PR DESCRIPTION
As discussed, this checks for `EINTR` on `tcsetattr`. I did not use the glibc macro, as that makes it harder for me to port rather than easier.
