### PR TITLE
Use OpenBSD's reallocarray instead of realloc(p, s * n)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 override CFLAGS+=-Wall -Werror -D_GNU_SOURCE -g
-OBJS=reptyr.o ptrace.o attach.o
+OBJS=reptyr.o ptrace.o reallocarray.o attach.o
 
 # Note that because of how Make works, this can be overriden from the
 # command-line.
@@ -12,7 +12,7 @@ all: reptyr
 reptyr: $(OBJS)
 
 attach.o: reptyr.h ptrace.h
-reptyr.o: reptyr.h
+reptyr.o: reptyr.h reallocarray.h
 ptrace.o: ptrace.h $(wildcard arch/*.h)
 
 clean:

--- a/attach.c
+++ b/attach.c
@@ -39,6 +39,7 @@
 
 #include "ptrace.h"
 #include "reptyr.h"
+#include "reallocarray.h"
 
 #define TASK_COMM_LENGTH 16
 struct proc_stat {
@@ -145,7 +146,7 @@ int *get_child_tty_fds(struct ptrace_child *child, int statfd, int *count) {
             || st.st_rdev == console_st.st_rdev) {
             if (n == allocated) {
                 allocated = allocated ? 2 * allocated : 2;
-                tmp = realloc(fds, allocated * sizeof *tmp);
+                tmp = xreallocarray(fds, allocated, sizeof *tmp);
                 if (tmp == NULL) {
                   child->error = assert_nonzero(errno);
                   error("Unable to allocate memory for fd array.");

--- a/reallocarray.c
+++ b/reallocarray.c
@@ -1,0 +1,41 @@
+/*  $OpenBSD: reallocarray.c,v 1.1 2014/05/08 21:43:49 deraadt Exp $    */
+/*
+ * Copyright (c) 2008 Otto Moerbeek <otto@drijf.net>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/types.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "reallocarray.h"
+
+/*
+ * This is sqrt(SIZE_MAX+1), as s1*s2 <= SIZE_MAX
+ * if both s1 < MUL_NO_OVERFLOW and s2 < MUL_NO_OVERFLOW
+ */
+#define MUL_NO_OVERFLOW (1UL << (sizeof(size_t) * 4))
+
+void *
+xreallocarray(void *optr, size_t nmemb, size_t size)
+{
+    if ((nmemb >= MUL_NO_OVERFLOW || size >= MUL_NO_OVERFLOW) &&
+        nmemb > 0 && SIZE_MAX / nmemb < size) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    return realloc(optr, size * nmemb);
+}
+

--- a/reallocarray.h
+++ b/reallocarray.h
@@ -1,0 +1,7 @@
+#ifndef __reallocarray_h
+#define __reallocarray_h
+
+void * xreallocarray(void *optr, size_t nmemb, size_t size);
+
+#endif
+


### PR DESCRIPTION
Use OpenBSD's `reallocarray` in the super-rare case that fd \* sizeof int causes an integer overflow.
