### PR TITLE
Update ptrace.h

### DIFF
--- a/ptrace.h
+++ b/ptrace.h
@@ -23,6 +23,7 @@
 #define PTRACE_H
 
 #include <sys/ptrace.h>
+#include <sys/types.h>
 #include <sys/user.h>
 #include <unistd.h>
 


### PR DESCRIPTION
Unable to compile in CentOS/RHEL6.4. until this fix.

prevent the error: expected specifier-qualifier-list before ‘__uint16_t’