### PR TITLE
Make install more configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ endif
 #
 # e.g. install to /usr with `make PREFIX=/usr`
 PREFIX=/usr/local
+BINDIR=$(PREFIX)/bin
+MANDIR=$(PREFIX)/share/man
+
+PKG_CONFIG ?= pkg-config
 
 all: reptyr
 
@@ -39,15 +43,15 @@ ptrace.o: ptrace.h platform/platform.h $(wildcard platform/*/arch/*.h)
 clean:
 	rm -f reptyr $(OBJS) test/victim.o test/victim
 
-BASHCOMPDIR ?= $(shell pkg-config --variable=completionsdir bash-completion 2>/dev/null)
+BASHCOMPDIR ?= $(shell $(PKG_CONFIG) --variable=completionsdir bash-completion 2>/dev/null)
 
 install: reptyr
-	install -d -m 755 $(DESTDIR)$(PREFIX)/bin/
-	install -m 755 reptyr $(DESTDIR)$(PREFIX)/bin/reptyr
-	install -d -m 755 $(DESTDIR)$(PREFIX)/share/man/man1
-	install -m 644 reptyr.1 $(DESTDIR)$(PREFIX)/share/man/man1/reptyr.1
-	install -d -m 755 $(DESTDIR)$(PREFIX)/share/man/fr/man1
-	install -m 644 reptyr.fr.1 $(DESTDIR)$(PREFIX)/share/man/fr/man1/reptyr.1
+	install -d -m 755 $(DESTDIR)$(BINDIR)
+	install -m 755 reptyr $(DESTDIR)$(BINDIR)/reptyr
+	install -d -m 755 $(DESTDIR)$(MANDIR)/man1
+	install -m 644 reptyr.1 $(DESTDIR)$(MANDIR)/man1/reptyr.1
+	install -d -m 755 $(DESTDIR)$(MANDIR)/fr/man1
+	install -m 644 reptyr.fr.1 $(DESTDIR)$(MANDIR)/fr/man1/reptyr.1
 	bashcompdir=$(BASHCOMPDIR) ; \
 	test -z "$$bashcompdir" && bashcompdir=/etc/bash_completion.d ; \
 	install -d -m 755 $(DESTDIR)$$bashcompdir ; \


### PR DESCRIPTION
Some distros needs more flexibility. For example Exherbo uses `/usr/x86_64-pc-linux-gnu` as a `PREFIX` on x86 64bit platforms while man-pages still resides in `/usr/share/man`. Also some tools have target-specific prefix like `x86_64-pc-linux-gnu-pkg-config`.

- allow overriding BINDIR and MANDIR
- allow overriding pkg-config

