### PR TITLE
Add ptrace file cap on install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ BASHCOMPDIR ?= $(shell $(PKG_CONFIG) --variable=completionsdir bash-completion 2
 install: reptyr
 	install -d -m 755 $(DESTDIR)$(BINDIR)
 	install -m 755 reptyr $(DESTDIR)$(BINDIR)/reptyr
+	setcap cap_sys_ptrace=eip $(DESTDIR)$(BINDIR)/reptyr
 	install -d -m 755 $(DESTDIR)$(MANDIR)/man1
 	install -m 644 reptyr.1 $(DESTDIR)$(MANDIR)/man1/reptyr.1
 	install -d -m 755 $(DESTDIR)$(MANDIR)/fr/man1


### PR DESCRIPTION
This adds ptrace file capability to the `reptyr` binary on install. This means users with `ptrace_scope = 1` do not have to temporarily disable that setting to use reptyr.

Note this does introduce some security concerns: it is possible to escalate privileges by using an exploit on reptyr and ptracing a process with the same UID and the capability required. However, this is still more secure than having `ptrace_scope = 0`.