### PR TITLE
Use pselect to avoid a WINCH race

### DIFF
--- a/reptyr.c
+++ b/reptyr.c
@@ -124,20 +124,34 @@ void do_proxy(int pty) {
     char buf[4096];
     ssize_t count;
     fd_set set;
+    sigset_t mask;
+    sigset_t select_mask;
+    struct sigaction sa;
+
+    // Block WINCH while we're outside the select, but unblock it
+    // while we're inside:
+    sigemptyset(&mask);
+    sigaddset(&mask, SIGWINCH);
+    if (sigprocmask(SIG_BLOCK, &mask, NULL) == -1) {
+        fprintf(stderr, "sigprocmask: %m");
+        return;
+    }
+    sa.sa_handler = do_winch;
+    sa.sa_flags = 0;
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGWINCH, &sa, NULL);
+    resize_pty(pty);
+
     while (1) {
         if (winch_happened) {
             winch_happened = 0;
-            /*
-             * minor race: If a signal comes in after this point but
-             * before select(), the resize will be delayed until we
-             * get more input. signalfd() or pselect() could fix this.
-             */
             resize_pty(pty);
         }
         FD_ZERO(&set);
         FD_SET(0, &set);
         FD_SET(pty, &set);
-        if (select(pty + 1, &set, NULL, NULL, NULL) < 0) {
+        sigemptyset(&select_mask);
+        if (pselect(pty + 1, &set, NULL, NULL, NULL, &select_mask) < 0) {
             if (errno == EINTR)
                 continue;
             fprintf(stderr, "select: %m");
@@ -176,7 +190,6 @@ void usage(char *me) {
 
 int main(int argc, char **argv) {
     struct termios saved_termios;
-    struct sigaction act;
     int pty;
     int opt;
     int err;
@@ -284,11 +297,6 @@ int main(int argc, char **argv) {
     }
 
     setup_raw(&saved_termios);
-    memset(&act, 0, sizeof act);
-    act.sa_handler = do_winch;
-    act.sa_flags   = 0;
-    sigaction(SIGWINCH, &act, NULL);
-    resize_pty(pty);
     do_proxy(pty);
     do {
         errno = 0;


### PR DESCRIPTION
This change should take care of the FIXME comment about the `SIGWINCH` race (probably a very silly race, but I guess fewer FIXMEs are good) by using `pselect`: I totally used https://lwn.net/Articles/176911/ as a reference to crib from.
