### PR TITLE
fix broken url

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,4 +118,4 @@ with any questions or bug reports.
 
 URL
 ---
-[http://github.com/nelhage/reptyr]()
+http://github.com/nelhage/reptyr


### PR DESCRIPTION
not sure why github rewrote it to `https://github.com/nelhage/reptyr/blob/master` before, which is a broken url, but this fixes it.

it's probably just "working around" a bug with github, but the []() ins't needed in this case anyway and the other working alternative would be to have the url both places