### PR TITLE
Fix prototype for get_pt

### DIFF
--- a/platform/platform.h
+++ b/platform/platform.h
@@ -79,7 +79,7 @@ int check_proc_stopped(pid_t pid, int fd);
 int *get_child_tty_fds(struct ptrace_child *child, int statfd, int *count);
 int get_terminal_state(struct steal_pty_state *steal, pid_t target);
 int find_master_fd(struct steal_pty_state *steal);
-int get_pt();
+int get_pt(void);
 int get_process_tty_termios(pid_t pid, struct termios *tio);
 void move_process_group(struct ptrace_child *child, pid_t from, pid_t to);
 void copy_user(struct ptrace_child *d, struct ptrace_child *s);


### PR DESCRIPTION
When `void` is missing it means the arguments to the function are not
specified, not that there are no arguments.