### PR TITLE
Fix Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 script: make test
-sudo: false
+sudo: required
 language: python
 python:
   - "2.7"

--- a/attach.c
+++ b/attach.c
@@ -559,6 +559,7 @@ int steal_pty(pid_t pid, int *pty) {
         goto out;
 
     debug("Listening on socket: %s", steal.addr_un.sun_path);
+    debug("Attaching terminal emulator pid=%d", steal.emulator_pid);
 
     if ((err = grab_pid(steal.emulator_pid, &steal.child, &steal.child_scratch)))
         goto out;

--- a/test/basic.py
+++ b/test/basic.py
@@ -1,11 +1,13 @@
 import pexpect
+import sys
 
 child = pexpect.spawn("test/victim")
 child.setecho(False)
 child.sendline("hello")
 child.expect("ECHO: hello")
 
-reptyr = pexpect.spawn("./reptyr %d" % (child.pid,))
+reptyr = pexpect.spawn("./reptyr -V %d" % (child.pid,))
+reptyr.logfile = sys.stdout
 reptyr.sendline("world")
 reptyr.expect("ECHO: world")
 

--- a/test/basic.py
+++ b/test/basic.py
@@ -2,6 +2,7 @@ import pexpect
 import sys
 
 child = pexpect.spawn("test/victim")
+child.logfile = sys.stdout
 child.setecho(False)
 child.sendline("hello")
 child.expect("ECHO: hello")

--- a/test/tty-steal.py
+++ b/test/tty-steal.py
@@ -6,13 +6,18 @@ if os.getenv("NO_TEST_STEAL") is not None:
     print("Skipping tty-stealing tests because $NO_TEST_STEAL is set.")
     sys.exit(0)
 
+did_prctl = False
 try:
     import prctl
     PR_SET_PTRACER_ANY = 0xffffffff
     if hasattr(prctl, 'set_ptracer'):
+        did_prctl = True
         prctl.set_ptracer(PR_SET_PTRACER_ANY)
 except ImportError:
-    print("Unable to import `prctl`, skipping `PR_SET_PTRACER`.")
+    pass
+
+if not did_prctl:
+  print("Unable to find `prctl.set_ptracer`, skipping `PR_SET_PTRACER`.")
 
 child = pexpect.spawn("test/victim")
 child.setecho(False)

--- a/test/tty-steal.py
+++ b/test/tty-steal.py
@@ -19,7 +19,10 @@ child.setecho(False)
 child.sendline("hello")
 child.expect("ECHO: hello")
 
-reptyr = pexpect.spawn("./reptyr -T %d" % (child.pid,))
+reptyr = pexpect.spawn("./reptyr -V -T %d" % (child.pid,))
+print("spawned children: me={} victim={} reptyr={}".format(os.getpid(), child.pid, reptyr.pid))
+reptyr.logfile = sys.stdout
+
 reptyr.sendline("world")
 reptyr.expect("ECHO: world")
 

--- a/test/victim.c
+++ b/test/victim.c
@@ -1,13 +1,22 @@
 #include <stdio.h>
 #include <sys/prctl.h>
 
+#ifndef PR_SET_PTRACER
+#define PR_SET_PTRACER
+#endif
+
+#ifndef PR_SET_PTRACER_ANY
+# define PR_SET_PTRACER_ANY ((unsigned long)-1)
+#endif
+
 int main(int argc, char **argv) {
     char *line = NULL;
     size_t cap = 0;
 
-#ifdef PR_SET_PTRACER
-    prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY);
-#endif
+    int err = prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY);
+    if (err != 0) {
+        fprintf(stderr, "Unable to PR_SET_PTRACER: %m\n");
+    }
 
     while(getline(&line, &cap, stdin) != -1) {
         printf("ECHO: %s", line);


### PR DESCRIPTION
After adding a whole bunch of debugging, conclude that `ptrace` just seems to be ~completely blocked inside Travis' containers, so go back to VMs.