### PR TITLE
Implement PowerPC architecture support.

### DIFF
--- a/platform/linux/arch/powerpc.h
+++ b/platform/linux/arch/powerpc.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2011 by Nelson Elhage
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+static struct ptrace_personality arch_personality[1] = {
+    {
+        offsetof(struct user, regs.gpr[3]),
+        offsetof(struct user, regs.gpr[3]),
+        offsetof(struct user, regs.gpr[4]),
+        offsetof(struct user, regs.gpr[5]),
+        offsetof(struct user, regs.gpr[6]),
+        offsetof(struct user, regs.gpr[7]),
+        offsetof(struct user, regs.gpr[8]),
+        offsetof(struct user, regs.nip),
+    }
+};
+
+static const unsigned long r0off = offsetof(struct user, regs.gpr[0]);
+#define ptr(user, off) ((unsigned long*)((void*)(user)+(off)))
+
+static inline void arch_fixup_regs(struct ptrace_child *child) {
+    child->user.regs.nip -= 4;
+}
+
+static inline int arch_set_syscall(struct ptrace_child *child,
+                                   unsigned long sysno) {
+    return ptrace_command(child, PTRACE_POKEUSER, r0off, sysno);
+}
+
+static inline int arch_save_syscall(struct ptrace_child *child) {
+    child->saved_syscall = *ptr(&child->user, r0off);
+    return 0;
+}
+
+static inline int arch_restore_syscall(struct ptrace_child *child) {
+    return 0;
+}

--- a/platform/linux/arch/powerpc.h
+++ b/platform/linux/arch/powerpc.h
@@ -51,5 +51,5 @@ static inline int arch_save_syscall(struct ptrace_child *child) {
 }
 
 static inline int arch_restore_syscall(struct ptrace_child *child) {
-    return 0;
+    return arch_set_syscall(child, child->saved_syscall);
 }

--- a/platform/linux/linux_ptrace.c
+++ b/platform/linux/linux_ptrace.c
@@ -78,6 +78,8 @@ static struct ptrace_personality *personality(struct ptrace_child *child);
 #include "arch/i386.h"
 #elif defined(__arm__)
 #include "arch/arm.h"
+#elif defined(__powerpc__)
+#include "arch/powerpc.h"
 #else
 #error Unsupported architecture.
 #endif


### PR DESCRIPTION
Implemented and tested on Gentoo ppc 32-bit (kernel 4.17.6, gcc 7.3.0). ppc64 not yet tested. Reference issue #89 