### PR TITLE
Add support for Linux on aarch64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,8 @@ reptyr: $(OBJS)
 
 ifeq ($(DISABLE_TESTS),)
 test: reptyr test/victim PHONY
-	python test/basic.py
-	python test/tty-steal.py
+	python2 test/basic.py
+	python2 test/tty-steal.py
 else
 test: all
 endif

--- a/platform/freebsd/arch/default-syscalls.h
+++ b/platform/freebsd/arch/default-syscalls.h
@@ -1,14 +1,11 @@
 #define SC(name) .nr_##name = SYS_##name
 
 {
-#ifdef SYS_mmap
-    SC(mmap),
-#else
-    .nr_mmap = -1,
-#endif
 #ifdef SYS_mmap2
+    .nr_mmap = -1,
     SC(mmap2),
 #else
+    SC(mmap),
     .nr_mmap2 = -1,
 #endif
     SC(munmap),
@@ -16,6 +13,7 @@
     SC(setsid),
     SC(setpgid),
     SC(fork),
+    .nr_clone = -1,
     SC(wait4),
 #ifdef SYS_signal
     SC(signal),
@@ -23,10 +21,11 @@
      .nr_signal = -1,
 #endif
     .nr_rt_sigaction = SYS_sigaction,
-    SC(open),
+    SC(openat),
     SC(close),
     SC(ioctl),
     SC(dup2),
+    .nr_dup3 = -1,
 #ifdef SYS_socketcall
     SC(socketcall),
 #else

--- a/platform/freebsd/arch/x86_common.h
+++ b/platform/freebsd/arch/x86_common.h
@@ -34,7 +34,7 @@ static inline void arch_fixup_regs(struct ptrace_child *child) {
     struct x86_personality *x86pers = x86_pers(child);
     struct ptrace_personality *pers = personality(child);
     struct reg *regs = &child->regs;
-#define ptr(user, off) ((unsigned long*)((void*)(user)+(off)))
+#define ptr(regs, off) ((unsigned long*)((void*)(regs)+(off)))
     *ptr(regs, pers->reg_ip) -= 2;
     *ptr(regs, x86pers->ax) = child->saved_syscall;
     //*ptr(user, x86pers->ax) = *ptr(user, x86pers->orig_ax);

--- a/platform/linux/arch/aarch64.h
+++ b/platform/linux/arch/aarch64.h
@@ -21,35 +21,41 @@
  */
 static struct ptrace_personality arch_personality[1] = {
     {
-        offsetof(struct user_regs, uregs[0]),
-        offsetof(struct user_regs, uregs[0]),
-        offsetof(struct user_regs, uregs[1]),
-        offsetof(struct user_regs, uregs[2]),
-        offsetof(struct user_regs, uregs[3]),
-        offsetof(struct user_regs, uregs[4]),
-        offsetof(struct user_regs, uregs[5]),
-        offsetof(struct user_regs, ARM_pc),
+        offsetof(struct user_regs_struct, regs[0]),
+        offsetof(struct user_regs_struct, regs[0]),
+        offsetof(struct user_regs_struct, regs[1]),
+        offsetof(struct user_regs_struct, regs[2]),
+        offsetof(struct user_regs_struct, regs[3]),
+        offsetof(struct user_regs_struct, regs[4]),
+        offsetof(struct user_regs_struct, regs[5]),
+        offsetof(struct user_regs_struct, pc),
     }
 };
 
 static inline void arch_fixup_regs(struct ptrace_child *child) {
-    child->regs.ARM_pc -= 4;
+    child->regs.pc -= 4;
 }
 
 static inline int arch_set_syscall(struct ptrace_child *child,
                                    unsigned long sysno) {
-    return ptrace_command(child, PTRACE_SET_SYSCALL, 0, sysno);
+    int syscall_reg = sysno;
+    struct iovec reg_iovec = {
+        .iov_base = &syscall_reg,
+        .iov_len = sizeof(syscall_reg)
+    };
+    return ptrace_command(child, PTRACE_SETREGSET, NT_ARM_SYSTEM_CALL, &reg_iovec);
 }
 
 static inline int arch_save_syscall(struct ptrace_child *child) {
-    unsigned long swi;
-    swi = ptrace_command(child, PTRACE_PEEKTEXT, child->regs.ARM_pc);
-    if (child->error)
+    int syscall_reg;
+    struct iovec reg_iovec = {
+        .iov_base = &syscall_reg,
+        .iov_len = sizeof(syscall_reg)
+    };
+    if (ptrace_command(child, PTRACE_GETREGSET, NT_ARM_SYSTEM_CALL, &reg_iovec) < 0)
         return -1;
-    if (swi == 0xef000000)
-        child->saved_syscall = child->regs.uregs[7];
-    else
-        child->saved_syscall = (swi & 0x000fffff);
+
+    child->saved_syscall = syscall_reg;
     return 0;
 }
 

--- a/platform/linux/arch/amd64.h
+++ b/platform/linux/arch/amd64.h
@@ -25,35 +25,35 @@
 
 static struct ptrace_personality arch_personality[2] = {
     {
-        offsetof(struct user, regs.rax),
-        offsetof(struct user, regs.rdi),
-        offsetof(struct user, regs.rsi),
-        offsetof(struct user, regs.rdx),
-        offsetof(struct user, regs.r10),
-        offsetof(struct user, regs.r8),
-        offsetof(struct user, regs.r9),
-        offsetof(struct user, regs.rip),
+        offsetof(struct user_regs_struct, rax),
+        offsetof(struct user_regs_struct, rdi),
+        offsetof(struct user_regs_struct, rsi),
+        offsetof(struct user_regs_struct, rdx),
+        offsetof(struct user_regs_struct, r10),
+        offsetof(struct user_regs_struct, r8),
+        offsetof(struct user_regs_struct, r9),
+        offsetof(struct user_regs_struct, rip),
     },
     {
-        offsetof(struct user, regs.rax),
-        offsetof(struct user, regs.rbx),
-        offsetof(struct user, regs.rcx),
-        offsetof(struct user, regs.rdx),
-        offsetof(struct user, regs.rsi),
-        offsetof(struct user, regs.rdi),
-        offsetof(struct user, regs.rbp),
-        offsetof(struct user, regs.rip),
+        offsetof(struct user_regs_struct, rax),
+        offsetof(struct user_regs_struct, rbx),
+        offsetof(struct user_regs_struct, rcx),
+        offsetof(struct user_regs_struct, rdx),
+        offsetof(struct user_regs_struct, rsi),
+        offsetof(struct user_regs_struct, rdi),
+        offsetof(struct user_regs_struct, rbp),
+        offsetof(struct user_regs_struct, rip),
     },
 };
 
 struct x86_personality x86_personality[2] = {
     {
-        offsetof(struct user, regs.orig_rax),
-        offsetof(struct user, regs.rax),
+        offsetof(struct user_regs_struct, orig_rax),
+        offsetof(struct user_regs_struct, rax),
     },
     {
-        offsetof(struct user, regs.orig_rax),
-        offsetof(struct user, regs.rax),
+        offsetof(struct user_regs_struct, orig_rax),
+        offsetof(struct user_regs_struct, rax),
     },
 };
 
@@ -77,7 +77,7 @@ struct syscall_numbers arch_syscall_numbers[2] = {
         .nr_wait4   = 114,
         .nr_signal  = 48,
         .nr_rt_sigaction = 174,
-        .nr_open    = 5,
+        .nr_openat  = 295,
         .nr_close   = 6,
         .nr_ioctl   = 54,
         .nr_dup2    = 63,
@@ -89,7 +89,7 @@ int arch_get_personality(struct ptrace_child *child) {
     unsigned long cs;
 
     cs = ptrace_command(child, PTRACE_PEEKUSER,
-                        offsetof(struct user, regs.cs));
+                        offsetof(struct user_regs_struct, cs));
     if (child->error)
         return -1;
     if (cs == 0x23)

--- a/platform/linux/arch/default-syscalls.h
+++ b/platform/linux/arch/default-syscalls.h
@@ -1,21 +1,24 @@
 #define SC(name) .nr_##name = __NR_##name
 
 {
-#ifdef __NR_mmap
-    SC(mmap),
-#else
-    .nr_mmap = -1,
-#endif
 #ifdef __NR_mmap2
+    .nr_mmap = -1,
     SC(mmap2),
 #else
+    SC(mmap),
     .nr_mmap2 = -1,
 #endif
     SC(munmap),
     SC(getsid),
     SC(setsid),
     SC(setpgid),
+#ifdef __NR_fork
     SC(fork),
+    .nr_clone = -1,
+#else
+    .nr_fork = -1,
+    SC(clone),
+#endif
     SC(wait4),
 #ifdef __NR_signal
     SC(signal),
@@ -23,10 +26,16 @@
      .nr_signal = -1,
 #endif
     SC(rt_sigaction),
-    SC(open),
+    SC(openat),
     SC(close),
     SC(ioctl),
+#ifdef __NR_dup2
     SC(dup2),
+    .nr_dup3 = -1,
+#else
+    .nr_dup2 = -1,
+    SC(dup3),
+#endif
 #ifdef __NR_socketcall
     SC(socketcall),
 #else

--- a/platform/linux/arch/i386.h
+++ b/platform/linux/arch/i386.h
@@ -23,20 +23,20 @@
 
 static struct ptrace_personality arch_personality[1] = {
     {
-        offsetof(struct user, regs.eax),
-        offsetof(struct user, regs.ebx),
-        offsetof(struct user, regs.ecx),
-        offsetof(struct user, regs.edx),
-        offsetof(struct user, regs.esi),
-        offsetof(struct user, regs.edi),
-        offsetof(struct user, regs.ebp),
-        offsetof(struct user, regs.eip),
+        offsetof(struct user_regs_struct, eax),
+        offsetof(struct user_regs_struct, ebx),
+        offsetof(struct user_regs_struct, ecx),
+        offsetof(struct user_regs_struct, edx),
+        offsetof(struct user_regs_struct, esi),
+        offsetof(struct user_regs_struct, edi),
+        offsetof(struct user_regs_struct, ebp),
+        offsetof(struct user_regs_struct, eip),
     }
 };
 
 struct x86_personality x86_personality[1] = {
     {
-        offsetof(struct user, regs.orig_eax),
-        offsetof(struct user, regs.eax),
+        offsetof(struct user_regs_struct, orig_eax),
+        offsetof(struct user_regs_struct, eax),
     }
 };

--- a/platform/linux/arch/powerpc.h
+++ b/platform/linux/arch/powerpc.h
@@ -22,22 +22,21 @@
 
 static struct ptrace_personality arch_personality[1] = {
     {
-        offsetof(struct user, regs.gpr[3]),
-        offsetof(struct user, regs.gpr[3]),
-        offsetof(struct user, regs.gpr[4]),
-        offsetof(struct user, regs.gpr[5]),
-        offsetof(struct user, regs.gpr[6]),
-        offsetof(struct user, regs.gpr[7]),
-        offsetof(struct user, regs.gpr[8]),
-        offsetof(struct user, regs.nip),
+        offsetof(struct pt_regs, gpr[3]),
+        offsetof(struct pt_regs, gpr[3]),
+        offsetof(struct pt_regs, gpr[4]),
+        offsetof(struct pt_regs, gpr[5]),
+        offsetof(struct pt_regs, gpr[6]),
+        offsetof(struct pt_regs, gpr[7]),
+        offsetof(struct pt_regs, gpr[8]),
+        offsetof(struct pt_regs, nip),
     }
 };
 
-static const unsigned long r0off = offsetof(struct user, regs.gpr[0]);
-#define ptr(user, off) ((unsigned long*)((void*)(user)+(off)))
+static const unsigned long r0off = offsetof(struct pt_regs, gpr[0]);
 
 static inline void arch_fixup_regs(struct ptrace_child *child) {
-    child->user.regs.nip -= 4;
+    child->regs.nip -= 4;
 }
 
 static inline int arch_set_syscall(struct ptrace_child *child,
@@ -46,7 +45,7 @@ static inline int arch_set_syscall(struct ptrace_child *child,
 }
 
 static inline int arch_save_syscall(struct ptrace_child *child) {
-    child->saved_syscall = *ptr(&child->user, r0off);
+    child->saved_syscall = *ptr(&child->regs, r0off);
     return 0;
 }
 

--- a/platform/linux/arch/x86_common.h
+++ b/platform/linux/arch/x86_common.h
@@ -34,10 +34,9 @@ static inline struct x86_personality *x86_pers(struct ptrace_child *child) {
 static inline void arch_fixup_regs(struct ptrace_child *child) {
     struct x86_personality *x86pers = x86_pers(child);
     struct ptrace_personality *pers = personality(child);
-    struct user *user = &child->user;
-#define ptr(user, off) ((unsigned long*)((void*)(user)+(off)))
-    *ptr(user, pers->reg_ip) -= 2;
-    *ptr(user, x86pers->ax) = *ptr(user, x86pers->orig_ax);
+    struct user_regs_struct *regs = &child->regs;
+    *ptr(regs, pers->reg_ip) -= 2;
+    *ptr(regs, x86pers->ax) = *ptr(regs, x86pers->orig_ax);
 }
 
 static inline int arch_set_syscall(struct ptrace_child *child,
@@ -48,12 +47,10 @@ static inline int arch_set_syscall(struct ptrace_child *child,
 }
 
 static inline int arch_save_syscall(struct ptrace_child *child) {
-    child->saved_syscall = *ptr(&child->user, x86_pers(child)->orig_ax);
+    child->saved_syscall = *ptr(&child->regs, x86_pers(child)->orig_ax);
     return 0;
 }
 
 static inline int arch_restore_syscall(struct ptrace_child *child) {
     return 0;
 }
-
-#undef ptr

--- a/platform/linux/linux.c
+++ b/platform/linux/linux.c
@@ -402,7 +402,7 @@ void move_process_group(struct ptrace_child *child, pid_t from, pid_t to) {
 }
 
 void copy_user(struct ptrace_child *d, struct ptrace_child *s) {
-    memcpy(&d->user, &s->user, sizeof(s->user));
+    memcpy(&d->regs, &s->regs, sizeof(s->regs));
 }
 
 unsigned long ptrace_socketcall(struct ptrace_child *child,

--- a/ptrace.h
+++ b/ptrace.h
@@ -63,9 +63,14 @@ struct ptrace_child {
     unsigned long forked_pid;
     unsigned long saved_syscall;
 #ifdef __linux__
-	struct user user;
+#ifdef __arm__
+    struct user_regs regs;
+#elif defined(__powerpc__)
+    struct pt_regs regs;
+#else
+    struct user_regs_struct regs;
 #endif
-#ifdef __FreeBSD__
+#elif defined(__FreeBSD__)
 	struct reg regs;
 #endif
 };
@@ -78,13 +83,15 @@ struct syscall_numbers {
     long nr_setsid;
     long nr_setpgid;
     long nr_fork;
+    long nr_clone;
     long nr_wait4;
     long nr_signal;
     long nr_rt_sigaction;
-    long nr_open;
+    long nr_openat;
     long nr_close;
     long nr_ioctl;
     long nr_dup2;
+    long nr_dup3;
     long nr_socket;
     long nr_connect;
     long nr_sendmsg;


### PR DESCRIPTION
This PR adds support for Linux on aarch64, which requires a number of changes besides the arch specific header.

Being a more recently architecture, Linux on aarch64 does not implement older syscalls such as `open`, `fork` and `dup2`. I added compatibility wrappers that emulate `fork` using `clone` and `dup2` using `dup3`. I replaced `open` with `openat`, which I believe is available on all supported systems.

aarch64 also does not support certain ptrace requests, such as `PTRACE_GETREGS`, `PTRACE_SETREGS`, `PTRACE_PEEKUSER` and `PTRACE_POKEUSER`. Instead, `PTRACE_GETREGSET` and `PTRACE_SETREGSET` must be used for all register manipulations. I believe these are available on all supported systems, so we shouldn't need special cases for aarch64.

I also switched from using the `user` struct to using `user_regs_struct`/`user_regs`/`pt_regs` depending on the architecture. aarch64 does not have a `user` struct, and I felt that it would be more clear and consistent to use just the register struct on all arches. AFAIK, ptrace only fills the register part of the `user` struct anyway.

I have tested these changes under Linux on x86_64, armv6l, armv7l, aarch64, and powerpc.

I attempted to test on FreeBSD 11.2, but running reptyr (even without this PR) results in a kernel panic. Besides whatever is wrong with reptyr, an unprivileged user being able to cause a panic seems like a fairly serious FreeBSD bug.

<details>
  <summary>Panic backtrace</summary>

```
Fatal trap 12: page fault while in kernel mode
cpuid = 0; apic id = 00
fault virtual address	= 0x2b0
fault code		= supervisor write data, page not present
instruction pointer	= 0x20:0xffffffff80b60eea
stack pointer	        = 0x28:0xfffffe007af43760
frame pointer	        = 0x28:0xfffffe007af43880
code segment		= base 0x0, limit 0xfffff, type 0x1b
			= DPL 0, pres 1, long 1, def32 0, gran 1
processor eflags	= interrupt enabled, resume, IOPL = 0
current process		= 747 (reptyr)
trap number		= 12
panic: page fault
cpuid = 0
KDB: stack backtrace:
#0 0xffffffff80b3d567 at kdb_backtrace+0x67
#1 0xffffffff80af6b07 at vpanic+0x177
#2 0xffffffff80af6983 at panic+0x43
#3 0xffffffff80f77faf at trap_fatal+0x35f
#4 0xffffffff80f78009 at trap_pfault+0x49
#5 0xffffffff80f777d7 at trap+0x2c7
#6 0xffffffff80f5769c at calltrap+0x8
#7 0xffffffff80b5fa3d at sys_ptrace+0x18d
#8 0xffffffff80f79038 at amd64_syscall+0xa38
#9 0xffffffff80f57eed at fast_syscall_common+0x101
```

</details>