### PR TITLE
Fix usage on FreeBSD after c6f10c6db3f0

### DIFF
--- a/attach.c
+++ b/attach.c
@@ -117,8 +117,8 @@ int do_setsid(struct ptrace_child *child) {
 
 out_kill:
     kill(dummy.pid, SIGKILL);
-    ptrace_wait(&dummy);
     ptrace_detach_child(&dummy);
+    ptrace_wait(&dummy);
     do_syscall(child, wait4, dummy.pid, 0, WNOHANG, 0, 0, 0);
     return err;
 }


### PR DESCRIPTION
This commit added a ptrace_wait to reap the dummy before
ptrace_detach_child.  On FreeBSD, this leaves us stuck waiting on a child
that cannot be reaped because ptrace is still attached.

Signed-off-by: Kyle Evans <kevans@FreeBSD.org>