### PR TITLE
freebsd: ignore fd < 0 in the vnodes returned

### DIFF
--- a/platform/freebsd/freebsd.c
+++ b/platform/freebsd/freebsd.c
@@ -107,7 +107,7 @@ int *get_child_tty_fds(struct ptrace_child *child, int statfd, int *count) {
                 goto out;
             }
 
-            if (vn.vn_dev == kp->ki_tdev) {
+            if (vn.vn_dev == kp->ki_tdev && fst->fs_fd >= 0) {
                 if (fd_array_push(&fds, fst->fs_fd) != 0) {
                     error("Unable to allocate memory for fd array.");
                     goto out;


### PR DESCRIPTION
This is a possibility, and reptyr does not care about these. This is mostly
a cosmetic issue, as reptyr then complains because it can't use dup2() on
fd=-1.

Signed-off-by: Kyle Evans <kevans@FreeBSD.org>