### PR TITLE
Fix the TravisCI build

### DIFF
--- a/test/basic.py
+++ b/test/basic.py
@@ -1,6 +1,8 @@
 import pexpect
 import sys
 
+from util import expect_eof
+
 child = pexpect.spawn("test/victim")
 child.logfile = sys.stdout
 child.setecho(False)
@@ -13,7 +15,7 @@ reptyr.sendline("world")
 reptyr.expect("ECHO: world")
 
 child.sendline("final")
-child.expect(pexpect.EOF)
+expect_eof(child.child_fd)
 
 reptyr.sendeof()
 reptyr.expect(pexpect.EOF)

--- a/test/tty-steal.py
+++ b/test/tty-steal.py
@@ -2,6 +2,8 @@ import pexpect
 import os
 import sys
 
+from util import expect_eof
+
 if os.getenv("NO_TEST_STEAL") is not None:
     print("Skipping tty-stealing tests because $NO_TEST_STEAL is set.")
     sys.exit(0)
@@ -32,7 +34,7 @@ reptyr.sendline("world")
 reptyr.expect("ECHO: world")
 
 child.sendline("final")
-child.expect(pexpect.EOF)
+expect_eof(child.child_fd)
 assert os.stat("/dev/null").st_rdev == os.fstat(child.fileno()).st_rdev
 
 reptyr.sendeof()

--- a/test/util.py
+++ b/test/util.py
@@ -1,0 +1,17 @@
+import os
+import errno
+import select
+
+def expect_eof(fd):
+  r, _, _ = select.select([fd], [], [])
+  if fd not in r:
+    raise AssertionError("Expected EOF, fd not readable")
+  try:
+    data = os.read(fd, 1024)
+    if len(data) == 0:
+      return
+    raise AssertionError("Expected EOF, got read: `{}'".format(data))
+  except OSError as e:
+    if e.errno == errno.EIO:
+      return
+    raise AssertionError("Expected EOF, other expection: {}".format(e))


### PR DESCRIPTION
pexpect.EOF apparently waits for the child to die

We actually just want to check for EOF on that FD.

I'm not entirely sure how this ever worked, now.