### PR TITLE
Add Cirrus CI support, Linux build+test and FreeBSD build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,30 @@
+freebsd_12_task:
+  freebsd_instance:
+    image: freebsd-12-1-release-amd64
+  install_script:
+    pkg install -y gmake
+  build_script:
+    gmake
+
+linux_gcc_py2_task:
+  container:
+    image: gcc:latest
+  install_script:
+    - apt-get update
+    - apt-get install -y python-prctl python-pexpect
+  build_script:
+    - make
+  test_script:
+    - make test
+
+linux_gcc_py3_task:
+  container:
+    image: gcc:latest
+  install_script:
+    - apt-get update
+    - apt-get install -y python3-prctl python3-pexpect
+  build_script:
+    - make
+  test_script:
+    - make test PYTHON_CMD=python3
+


### PR DESCRIPTION
Signed-off-by: Kyle Evans <kevans@FreeBSD.org>

--

You can visit https://cirrus-ci.com to sign up for the integration with GitHub to view the results easily. I'm still working out test details locally here on FreeBSD, but I can at least confirm that the tests are OK under Cirrus' Linux setup, at least.