### PR TITLE
test: modify a bit for other-platform/python compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ BINDIR=$(PREFIX)/bin
 MANDIR=$(PREFIX)/share/man
 
 PKG_CONFIG ?= pkg-config
+PYTHON_CMD ?= python2
 
 all: reptyr
 
@@ -24,8 +25,8 @@ reptyr: $(OBJS)
 
 ifeq ($(DISABLE_TESTS),)
 test: reptyr test/victim PHONY
-	python2 test/basic.py
-	python2 test/tty-steal.py
+	$(PYTHON_CMD) test/basic.py
+	$(PYTHON_CMD) test/tty-steal.py
 else
 test: all
 endif

--- a/test/basic.py
+++ b/test/basic.py
@@ -3,14 +3,18 @@ import sys
 
 from util import expect_eof
 
+logfile = sys.stdout
+if sys.version_info[0] >= 3:
+    logfile = logfile.buffer
+
 child = pexpect.spawn("test/victim")
-child.logfile = sys.stdout
+child.logfile = logfile
 child.setecho(False)
 child.sendline("hello")
 child.expect("ECHO: hello")
 
 reptyr = pexpect.spawn("./reptyr -V %d" % (child.pid,))
-reptyr.logfile = sys.stdout
+reptyr.logfile = logfile
 reptyr.sendline("world")
 reptyr.expect("ECHO: world")
 

--- a/test/tty-steal.py
+++ b/test/tty-steal.py
@@ -8,6 +8,10 @@ if os.getenv("NO_TEST_STEAL") is not None:
     print("Skipping tty-stealing tests because $NO_TEST_STEAL is set.")
     sys.exit(0)
 
+logfile = sys.stdout
+if sys.version_info[0] >= 3:
+    logfile = logfile.buffer
+
 did_prctl = False
 try:
     import prctl
@@ -28,7 +32,7 @@ child.expect("ECHO: hello")
 
 reptyr = pexpect.spawn("./reptyr -V -T %d" % (child.pid,))
 print("spawned children: me={} victim={} reptyr={}".format(os.getpid(), child.pid, reptyr.pid))
-reptyr.logfile = sys.stdout
+reptyr.logfile = logfile
 
 reptyr.sendline("world")
 reptyr.expect("ECHO: world")

--- a/test/victim.c
+++ b/test/victim.c
@@ -1,4 +1,6 @@
 #include <stdio.h>
+
+#ifdef __linux__
 #include <sys/prctl.h>
 
 #ifndef PR_SET_PTRACER
@@ -8,15 +10,18 @@
 #ifndef PR_SET_PTRACER_ANY
 # define PR_SET_PTRACER_ANY ((unsigned long)-1)
 #endif
+#endif
 
 int main(int argc, char **argv) {
     char *line = NULL;
     size_t cap = 0;
 
+#ifdef __linux__
     int err = prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY);
     if (err != 0) {
         fprintf(stderr, "Unable to PR_SET_PTRACER: %m\n");
     }
+#endif
 
     while(getline(&line, &cap, stdin) != -1) {
         printf("ECHO: %s", line);


### PR DESCRIPTION
My local master branch contains cirrus configs that tested both python2 and python3 compatibility on Linux -- neither work on FreeBSD still due to issues with the victim running under pexpect that I'm working over, but all tests passed on both versions with these relatively minor changes.

prctl-type manipulation isn't needed on FreeBSD, as we don't have any facility that will restrict PT_ATTACH beyond a bunch of bits that we wouldn't be able to affect anyways as the debugger.