### PR TITLE
FreeBSD: Fix tty stealing, enable at least that test

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,9 +2,11 @@ freebsd_12_task:
   freebsd_instance:
     image: freebsd-12-1-release-amd64
   install_script:
-    pkg install -y gmake
+    pkg install -y gmake py27-pexpect
   build_script:
     gmake
+  test_script:
+    - env NO_TEST_BASIC=yes gmake test PYTHON_CMD=python2.7
 
 linux_gcc_py2_task:
   container:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,3 +1,6 @@
+env:
+  CIRRUS_CLONE_DEPTH: 1
+
 freebsd_12_task:
   freebsd_instance:
     image: freebsd-12-1-release-amd64

--- a/platform/freebsd/freebsd.c
+++ b/platform/freebsd/freebsd.c
@@ -218,7 +218,6 @@ int find_master_fd(struct steal_pty_state *steal) {
     unsigned int cnt;
 
     head = get_procfiles(steal->child.pid, &kp, &procstat, &cnt);
-    procstat = procstat_open_sysctl();
 
     STAILQ_FOREACH(fst, head, next) {
         if (fst->fs_type != PS_FST_TYPE_PTS)

--- a/platform/freebsd/freebsd.c
+++ b/platform/freebsd/freebsd.c
@@ -157,6 +157,7 @@ int fill_proc_stat(struct steal_pty_state *steal, struct kinfo_proc *kp) {
     ps->ppid = kp->ki_ppid;
     ps->sid = kp->ki_sid;
     ps->pgid = kp->ki_pgid;
+    ps->ctty = kp->ki_tdev;
 
     return 0;
 }

--- a/platform/freebsd/freebsd.c
+++ b/platform/freebsd/freebsd.c
@@ -212,16 +212,28 @@ done:
 }
 
 int find_master_fd(struct steal_pty_state *steal) {
+    char errbuf[_POSIX2_LINE_MAX];
     struct filestat *fst;
     struct filestat_list *head;
     struct procstat *procstat;
     struct kinfo_proc *kp;
+    struct ptsstat pts;
     unsigned int cnt;
+    int err;
 
     head = get_procfiles(steal->child.pid, &kp, &procstat, &cnt);
 
     STAILQ_FOREACH(fst, head, next) {
         if (fst->fs_type != PS_FST_TYPE_PTS)
+            continue;
+
+        err = procstat_get_pts_info(procstat, fst, &pts, errbuf);
+        if (err != 0) {
+            error("error discovering fd=%d", fst->fs_fd);
+            continue;
+        }
+
+        if (pts.dev != steal->target_stat.ctty)
             continue;
 
         if (fd_array_push(&steal->master_fds, fst->fs_fd) != 0) {

--- a/test/basic.py
+++ b/test/basic.py
@@ -1,7 +1,12 @@
+import os
 import pexpect
 import sys
 
 from util import expect_eof
+
+if os.getenv("NO_TEST_BASIC") is not None:
+    print("Skipping basic tests because $NO_TEST_BASIC is set.")
+    sys.exit(0)
 
 logfile = sys.stdout
 if sys.version_info[0] >= 3:


### PR DESCRIPTION
As described in the commit messages, we actively haven't implemented TIOCNOTTY in at least 17 years. I have an implementation WIP, but it will be a while before this becomes usable from a CI standpoint. =-(

The tty-stealing test uncovered a bug in my implementation where I didn't actually make sure the master fds we were gathering corresponded to the victim (d'oh!). Easily fixed- do that, and now the tests pass and the implementation is more correct than my initial testing!

Thanks again for this fine piece of software. =)