### PR TITLE
Update ptrace.h: include <asm/ptrace.h> for Linux

### DIFF
--- a/ptrace.h
+++ b/ptrace.h
@@ -22,6 +22,9 @@
 #ifndef PTRACE_H
 #define PTRACE_H
 
+#ifdef __powerpc__
+#include <asm/ptrace.h>
+#endif
 #include <sys/ptrace.h>
 #include <sys/types.h>
 #include <sys/user.h>


### PR DESCRIPTION
This fixes compilation error, which was found while using musl for powerpc:

```
In file included from attach.c:43:0:
ptrace.h:69:20: error: field 'regs' has incomplete type
     struct pt_regs regs;
                    ^~~~
<builtin>: recipe for target 'attach.o' failed
```