### PR TITLE
freebsd: initialize count to 0 before procstat_getprocs()

### DIFF
--- a/platform/freebsd/freebsd.c
+++ b/platform/freebsd/freebsd.c
@@ -39,6 +39,7 @@ int check_pgroup(pid_t target) {
     pg = getpgid(target);
 
     procstat = procstat_open_sysctl();
+    cnt = 0;
     kp = procstat_getprocs(procstat, KERN_PROC_PGRP, pg, &cnt);
     procstat_freeprocs(procstat, kp);
     procstat_close(procstat);
@@ -58,6 +59,7 @@ int check_proc_stopped(pid_t pid, int fd) {
     unsigned int cnt;
 
     procstat = procstat_open_sysctl();
+    cnt = 0;
     kp = procstat_getprocs(procstat, KERN_PROC_PID, pid, &cnt);
 
     if (cnt > 0)
@@ -79,6 +81,7 @@ int check_proc_stopped(pid_t pid, int fd) {
 struct filestat_list* get_procfiles(pid_t pid, struct kinfo_proc **kp, struct procstat **procstat, unsigned int *cnt) {
     int mflg = 0; // include mmapped files
     (*procstat) = procstat_open_sysctl();
+    *cnt = 0;
     (*kp) = procstat_getprocs(*procstat, KERN_PROC_PID, pid, cnt);
     if ((*kp) == NULL || *cnt < 1)
         return NULL;
@@ -137,6 +140,7 @@ int find_terminal_emulator(struct steal_pty_state *steal) {
     unsigned int cnt;
 
     procstat = procstat_open_sysctl();
+    cnt = 0;
     kp = procstat_getprocs(procstat, KERN_PROC_PID, steal->target_stat.sid, &cnt);
 
     if (kp && cnt > 0)
@@ -145,7 +149,7 @@ int find_terminal_emulator(struct steal_pty_state *steal) {
     procstat_freeprocs(procstat, kp);
     procstat_close(procstat);
 
-    return 0;
+    return (cnt != 0 ? 0 : 1);
 }
 
 int fill_proc_stat(struct steal_pty_state *steal, struct kinfo_proc *kp) {
@@ -168,6 +172,7 @@ int grab_uid(pid_t pid, uid_t *out) {
     unsigned int cnt;
 
     procstat = procstat_open_sysctl();
+    cnt = 0;
     kp = procstat_getprocs(procstat, KERN_PROC_PID, pid, &cnt);
 
     if (kp && cnt > 0)
@@ -187,6 +192,7 @@ int get_terminal_state(struct steal_pty_state *steal, pid_t target) {
     int err = 0;
 
     procstat = procstat_open_sysctl();
+    cnt = 0;
     kp = procstat_getprocs(procstat, KERN_PROC_PID, target, &cnt);
     if (kp == NULL || cnt < 1)
         goto done;
@@ -300,6 +306,7 @@ void move_process_group(struct ptrace_child *child, pid_t from, pid_t to) {
     int err;
 
     procstat = procstat_open_sysctl();
+    cnt = 0;
     kp = procstat_getprocs(procstat, KERN_PROC_PGRP, from, &cnt);
 
     for (i = 0; i < cnt; i++) {


### PR DESCRIPTION
This API will not touch *count in the error case, so we're
left with stack garbage.

Signed-off-by: Kyle Evans <kevans91@ksu.edu>