### PR TITLE
fix(freebsd): Initialize state in check_proc_stopped.

### DIFF
--- a/platform/freebsd/freebsd.c
+++ b/platform/freebsd/freebsd.c
@@ -55,7 +55,7 @@ int check_pgroup(pid_t target) {
 int check_proc_stopped(pid_t pid, int fd) {
     struct procstat *procstat;
     struct kinfo_proc *kp;
-    int state;
+    int state = 0;
     unsigned int cnt;
 
     procstat = procstat_open_sysctl();


### PR DESCRIPTION
Technically this is a warning, but warnings treated as errors.