### PR TITLE
Fix up the Cirrus bits

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,3 @@
-env:
-  CIRRUS_CLONE_DEPTH: 1
-
 freebsd_12_task:
   freebsd_instance:
     image: freebsd-12-1-release-amd64

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,6 @@
 freebsd_12_task:
   freebsd_instance:
-    image: freebsd-12-1-release-amd64
+    image: freebsd-12-2-release-amd64
   install_script:
     pkg install -y gmake py37-pexpect
   build_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,11 +2,11 @@ freebsd_12_task:
   freebsd_instance:
     image: freebsd-12-1-release-amd64
   install_script:
-    pkg install -y gmake py27-pexpect
+    pkg install -y gmake py37-pexpect
   build_script:
     gmake
   test_script:
-    - env NO_TEST_BASIC=yes gmake test PYTHON_CMD=python2.7
+    - env NO_TEST_BASIC=yes gmake test PYTHON_CMD=python3.7
 
 linux_gcc_py2_task:
   container:


### PR DESCRIPTION
Notably:

- CIRRUS_CLONE_DEPTH is not necessary, the default is 50 and this is cargo-cult from the template I was using
- Switch to FreeBSD 12.2, 12.1 will go EoL at the end of this month
- Switch to Python 3.7, we've already removed the Python 2.7 flavor of py-pexpect in our Python 2.7 deprecation effort