### PR TITLE
Fix Linux ptrace event handling

### DIFF
--- a/platform/linux/linux_ptrace.c
+++ b/platform/linux/linux_ptrace.c
@@ -158,7 +158,8 @@ int ptrace_wait(struct ptrace_child *child) {
             child->state = (child->state == ptrace_at_syscall) ?
                            ptrace_after_syscall : ptrace_at_syscall;
         } else {
-            if (sig == SIGTRAP && (((child->status >> 8) & PTRACE_EVENT_FORK) == PTRACE_EVENT_FORK))
+            int event = child->status >> 16;
+            if (sig == SIGTRAP && event == PTRACE_EVENT_FORK)
                 ptrace_command(child, PTRACE_GETEVENTMSG, 0, &child->forked_pid);
             if (child->state != ptrace_at_syscall)
                 child->state = ptrace_stopped;


### PR DESCRIPTION
The code was previously using (status >> 8) & PTRACE_EVENT_FORK to check for
a fork event, but the event is in (status >> 16), and PTRACE_EVENT_* is an
enumeration, not a bit mask. What was actually being tested was the low bit of
the signal, which was always set (since SIGTRAP is 5).

Presumably the old code was working fine because the child PID is only used
immediately after a fork call, but this event handling is more correct.