### PR TITLE
x86_common.h: Fix buld under LLVM 13 on FreeBSD

### DIFF
--- a/platform/freebsd/arch/x86_common.h
+++ b/platform/freebsd/arch/x86_common.h
@@ -42,21 +42,19 @@ static inline void arch_fixup_regs(struct ptrace_child *child) {
 }
 
 static inline unsigned long arch_get_register(struct ptrace_child *child, unsigned long oft) {
-	int ret;
 	struct reg regs;
 
-	ret = ptrace_command(child, PT_GETREGS, &regs);
+	(void) ptrace_command(child, PT_GETREGS, &regs);
 
 	return *ptr(&regs,oft);
 }
 
 static inline void arch_set_register(struct ptrace_child *child, unsigned long oft, unsigned long val) {
-	int ret;
 	struct reg regs;
 
-	ret = ptrace_command(child, PT_GETREGS, &regs);
+	(void) ptrace_command(child, PT_GETREGS, &regs);
 	*ptr(&regs,oft)=val;
-	ret = ptrace_command(child, PT_SETREGS, &regs);
+	(void) ptrace_command(child, PT_SETREGS, &regs);
 }
 
 static inline int arch_save_syscall(struct ptrace_child *child) {


### PR DESCRIPTION
Fix the following error under LLVM 13 on FreeBSD.

In file included from platform/freebsd/freebsd_ptrace.c:69:
In file included from platform/freebsd/arch/amd64.h:23:
platform/freebsd/arch/x86_common.h:45:6: error: variable 'ret' set but not used [-Werror,-Wunused-but-set-variable]
        int ret;
            ^
platform/freebsd/arch/x86_common.h:54:6: error: variable 'ret' set but not used [-Werror,-Wunused-but-set-variable]
        int ret;
            ^
2 errors generated.