### PR TITLE
fix: expect EOL in test

### DIFF
--- a/test/basic.py
+++ b/test/basic.py
@@ -16,12 +16,12 @@ child = pexpect.spawn("test/victim")
 child.logfile = logfile
 child.setecho(False)
 child.sendline("hello")
-child.expect("ECHO: hello")
+child.expect("ECHO: hello\r\n")
 
 reptyr = pexpect.spawn("./reptyr -V %d" % (child.pid,))
 reptyr.logfile = logfile
 reptyr.sendline("world")
-reptyr.expect("ECHO: world")
+reptyr.expect("ECHO: world\r\n")
 
 child.sendline("final")
 expect_eof(child.child_fd)


### PR DESCRIPTION
ECHO: world
final
Traceback (most recent call last):
  File "test/basic.py", line 27, in <module>
    expect_eof(child.child_fd)
  File "/build/source/test/util.py", line 13, in expect_eof
    raise AssertionError("Expected EOF, got read: `{}'".format(data))
AssertionError: Expected EOF, got read: `
'

When I run in python3 I get `b"\r\n"`

Also a test I did to confirm:
```
42sh$ printf "a\r\nb\nc" | ./victim | xxd
00000000: 4543 484f 3a20 610d 0a45 4348 4f3a 2062  ECHO: a..ECHO: b
00000010: 0a45 4348 4f3a 2063                      .ECHO: c
```