### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 reptyr (0.9.0-2) UNRELEASED; urgency=medium
 
   * Use secure copyright file specification URI.
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
 
  -- Debian Janitor <janitor@jelmer.uk>  Sat, 03 Sep 2022 14:49:14 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+reptyr (0.9.0-2) UNRELEASED; urgency=medium
+
+  * Use secure copyright file specification URI.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Sat, 03 Sep 2022 14:49:14 -0000
+
 reptyr (0.9.0-1) unstable; urgency=medium
 
   * Acknowledge NMUs. (Thank you!)

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ reptyr (0.9.0-2) UNRELEASED; urgency=medium
   * Use secure copyright file specification URI.
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
     Repository-Browse.
+  * Update standards version to 4.6.1, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Sat, 03 Sep 2022 14:49:14 -0000
 

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper-compat (= 13),
                bash-completion,
                python3,
                python3-pexpect
-Standards-Version: 4.6.0
+Standards-Version: 4.6.1
 Homepage: https://github.com/nelhage/reptyr
 Vcs-Git: https://github.com/nelhage/reptyr.git -b debian
 Vcs-Browser: https://github.com/nelhage/reptyr/tree/debian

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,4 +1,4 @@
-Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: reptyr
 Upstream-Contact: Nelson Elhage <nelhage@nelhage.com>
 Source: https://github.com/nelhage/reptyr

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,5 @@
+---
+Bug-Database: https://github.com/nelhage/reptyr/issues
+Bug-Submit: https://github.com/nelhage/reptyr/issues/new
+Repository: https://github.com/nelhage/reptyr.git
+Repository-Browse: https://github.com/nelhage/reptyr


### PR DESCRIPTION
Fix some issues reported by lintian

* Use secure copyright file specification URI. ([insecure-copyright-format-uri](https://lintian.debian.org/tags/insecure-copyright-format-uri))
* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository))
* Update standards version to 4.6.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))

## Debdiff

These changes affect the binary packages:

[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/3e/28ec05d3ea6a3ac52563f278bf7b2bda6e082d.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/88/2427c953bb33cb711ecbbf16044b4e76ed43ea.debug

No differences were encountered between the control files of package \*\*reptyr\*\*
### Control files of package reptyr-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-882427c953bb33cb711ecbbf16044b4e76ed43ea-] {+3e28ec05d3ea6a3ac52563f278bf7b2bda6e082d+}

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/73c4234e-8f7c-4898-bbed-1fe56e10f90f/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/73c4234e-8f7c-4898-bbed-1fe56e10f90f/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/lintian-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/lintian-fixes/pkg/reptyr/73c4234e-8f7c-4898-bbed-1fe56e10f90f.