### PR TITLE
freebsd: add aarch64 support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,9 +1,9 @@
 freebsd_12_task:
   freebsd_instance:
-    image: freebsd-12-2-release-amd64
+    image: freebsd-12-4-release-amd64
   install_script:
-    pkg install -y gmake py38-pexpect
+    pkg install -y gmake py39-pexpect
   build_script:
     gmake
   test_script:
-    - env NO_TEST_BASIC=yes gmake test PYTHON_CMD=python3.8
+    - gmake test PYTHON_CMD=python3.9

--- a/platform/freebsd/arch/aarch64.h
+++ b/platform/freebsd/arch/aarch64.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2011 by Nelson Elhage
+ * Copyright (C) 2023 Kyle Evans <kevans@FreeBSD.org>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+static struct ptrace_personality arch_personality[1] = {
+    {
+        offsetof(struct reg, x[0]),
+        offsetof(struct reg, x[0]),
+        offsetof(struct reg, x[1]),
+        offsetof(struct reg, x[2]),
+        offsetof(struct reg, x[3]),
+        offsetof(struct reg, x[4]),
+        offsetof(struct reg, x[5]),
+        offsetof(struct reg, elr),
+    }
+};
+
+#define ptr(regs, off) ((unsigned long*)((void*)(regs)+(off)))
+
+static inline void arch_fixup_regs(struct ptrace_child *child) {
+    child->regs.elr -= 4;
+}
+
+static inline void arch_set_register(struct ptrace_child *child, unsigned long oft, unsigned long val)
+{
+    struct reg regs;
+
+    (void)ptrace_command(child, PT_GETREGS, &regs);
+    *ptr(&regs, oft) = val;
+    (void)ptrace_command(child, PT_SETREGS, &regs);
+}
+
+static inline int arch_save_syscall(struct ptrace_child *child) {
+    child->saved_syscall = child->regs.x[0];
+    return 0;
+}
+
+static inline int arch_set_syscall(struct ptrace_child *child,
+                                   unsigned long sysno) {
+    arch_set_register(child, offsetof(struct reg, x[8]), sysno);
+    return 0;
+}
+
+static inline int arch_restore_syscall(struct ptrace_child *child) {
+    return 0;
+}
+
+#undef ptr

--- a/platform/freebsd/arch/x86_common.h
+++ b/platform/freebsd/arch/x86_common.h
@@ -70,6 +70,12 @@ static inline int arch_get_syscall(struct ptrace_child *child,
                           //sysno);
 }
 
+static inline int arch_set_syscall(struct ptrace_child *child,
+                                   unsigned long sysno) {
+    arch_set_register(child, x86_pers(child)->ax, sysno);
+    return 0;
+}
+
 static inline int arch_restore_syscall(struct ptrace_child *child) {
     return 0;
 }

--- a/platform/freebsd/freebsd_ptrace.c
+++ b/platform/freebsd/freebsd_ptrace.c
@@ -71,6 +71,8 @@ static struct ptrace_personality *personality(struct ptrace_child *child);
 #include "arch/i386.h"
 #elif defined(__arm__)
 #include "arch/arm.h"
+#elif defined(__aarch64__)
+#include "arch/aarch64.h"
 #else
 #error Unsupported architecture.
 #endif

--- a/platform/freebsd/freebsd_ptrace.c
+++ b/platform/freebsd/freebsd_ptrace.c
@@ -231,7 +231,7 @@ unsigned long ptrace_remote_syscall(struct ptrace_child *child,
     //if (arch_set_syscall(child, sysno) < 0)
     //return -1;
 
-    setreg(syscall_rv, sysno);
+    arch_set_syscall(child, sysno);
 
     setreg(syscall_arg0, p0);
     setreg(syscall_arg1, p1);


### PR DESCRIPTION
This also has some minor cleanup of Cirrus config in it to bump versions and run the basic test now that we support TIOCNOTTY on all supported versions.