### PR TITLE
Add experimental macOS attach support

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,9 +1,9 @@
-freebsd_12_task:
+freebsd_13_task:
   freebsd_instance:
-    image: freebsd-12-4-release-amd64
+    image: freebsd-13-2-release-amd64
   install_script:
-    pkg install -y gmake py39-pexpect
+    pkg install -y gmake python311 py311-pexpect
   build_script:
     gmake
   test_script:
-    - gmake test PYTHON_CMD=python3.9
+    - gmake test PYTHON_CMD=python3.11

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ ifeq ($(UNAME_S),FreeBSD)
 	OBJS += platform/freebsd/freebsd_ptrace.o platform/freebsd/freebsd.o
 	LDFLAGS += -lprocstat
 endif
+ifeq ($(UNAME_S),Darwin)
+	OBJS += platform/darwin/darwin_ptrace.o platform/darwin/darwin.o platform/darwin/darwin_attach.o
+endif
 # Note that because of how Make works, this can be overridden from the
 # command-line.
 #
@@ -26,8 +29,13 @@ reptyr: $(OBJS)
 
 ifeq ($(DISABLE_TESTS),)
 test: reptyr test/victim PHONY
-	$(PYTHON_CMD) test/basic.py
-	$(PYTHON_CMD) test/tty-steal.py
+	$(PYTHON_CMD) test/list-pty.py
+	@if [ "$(UNAME_S)" = "Darwin" ]; then \
+		echo "Skipping Linux/FreeBSD ptrace attach tests on macOS; run 'make darwin-attach-test PYTHON_CMD=python3' for the experimental Darwin backend."; \
+	else \
+		$(PYTHON_CMD) test/basic.py; \
+		$(PYTHON_CMD) test/tty-steal.py; \
+	fi
 else
 test: all
 endif
@@ -38,8 +46,15 @@ test/victim: test/victim.o
 test/victim: override CFLAGS := $(VICTIM_CFLAGS)
 test/victim: override LDFLAGS := $(VICTIM_LDFLAGS)
 
+test/darwin-victim: test/darwin-victim.o
+test/darwin-victim: override CFLAGS := $(VICTIM_CFLAGS)
+test/darwin-victim: override LDFLAGS := $(VICTIM_LDFLAGS)
+
+darwin-attach-test: reptyr test/darwin-victim PHONY
+	$(PYTHON_CMD) test/darwin-basic.py
+
 clean:
-	rm -f reptyr $(OBJS) test/victim.o test/victim $(DEPS)
+	rm -f reptyr $(OBJS) test/victim.o test/victim test/darwin-victim.o test/darwin-victim $(DEPS)
 
 BASHCOMPDIR ?= $PREFIX/share/bash-completion/completions/
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,22 @@ PORTABILITY
 
 reptyr supports Linux and FreeBSD. Not all functionality is currently
 available on FreeBSD. (Notably, FreeBSD doesn't support `reptyr -T` at
-this time.
+this time.)
+
+macOS currently has partial support: `reptyr -l` and `reptyr -L` build
+and work, and an experimental Darwin backend supports `reptyr PID` and
+`reptyr -s PID` for same-user, debug-attachable arm64 targets. The Darwin
+attach path uses Mach task/thread APIs to temporarily hijack one target
+thread and run an arm64 syscall payload that opens the new pty and
+`dup2()`s it onto the target's tty fds. With `-s`, it redirects stdio fds
+0-2 directly.
+
+This is not full Linux/FreeBSD parity yet. `reptyr -T` is not implemented,
+Darwin attach is arm64-only, and targets may need ad-hoc signing with
+`com.apple.security.get-task-allow` or equivalent local debug permission
+for `task_for_pid()` to succeed. Programs that exit on an
+interrupted/aborted blocking read may still terminate during attach;
+interactive programs that retry reads are the expected first target class.
 
 `reptyr` uses ptrace to attach to the target and control it at the
 syscall level, so it is highly dependent on details of the syscall
@@ -103,6 +118,10 @@ actually changes the controlling terminal of the process you are
 attaching. I wrote a
 [blog post](https://blog.nelhage.com/2011/02/changing-ctty/)
 explaining just what the shenanigans involved are.
+
+The experimental macOS backend is not there yet: it redirects the target's
+open tty fds to the new pty, but does not currently change the target's
+controlling terminal or session state.
 
 PRONUNCIATION
 -------------

--- a/attach.c
+++ b/attach.c
@@ -267,6 +267,9 @@ int preflight_check(pid_t pid) {
 }
 
 int attach_child(pid_t pid, const char *pty, int force_stdio) {
+#ifdef __APPLE__
+    return darwin_attach_child(pid, pty, force_stdio);
+#else
     struct ptrace_child child;
     child_addr_t scratch_page = -1;
     int *child_tty_fds = NULL, n_fds, child_fd, statfd = -1;
@@ -400,6 +403,7 @@ out_cont:
 #endif
 
     return err < 0 ? -err : err;
+#endif
 }
 
 int setup_steal_socket(struct steal_pty_state *steal) {

--- a/platform/darwin/darwin.c
+++ b/platform/darwin/darwin.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2026 by reptyr contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifdef __APPLE__
+
+#include "darwin.h"
+#include "../platform.h"
+#include "../../reptyr.h"
+#include "../../ptrace.h"
+
+void check_ptrace_scope(void) {
+    error("macOS support is partial: targets must be debug-attachable, attach is arm64-only, and -T/control-tty handoff is not implemented yet.");
+}
+
+int check_pgroup(pid_t target) {
+    (void)target;
+    return 0;
+}
+
+int check_proc_stopped(pid_t pid, int fd) {
+    (void)pid;
+    (void)fd;
+    return 1;
+}
+
+int *get_child_tty_fds(struct ptrace_child *child, int statfd, int *count) {
+    (void)child;
+    (void)statfd;
+    *count = 0;
+    return NULL;
+}
+
+int get_terminal_state(struct steal_pty_state *steal, pid_t target) {
+    (void)steal;
+    (void)target;
+    return ENOTSUP;
+}
+
+int find_master_fd(struct steal_pty_state *steal) {
+    (void)steal;
+    return ENOTSUP;
+}
+
+int get_pt(void) {
+    return posix_openpt(O_RDWR | O_NOCTTY);
+}
+
+int get_process_tty_termios(pid_t pid, struct termios *tio) {
+    (void)pid;
+    (void)tio;
+    return ENOTSUP;
+}
+
+void move_process_group(struct ptrace_child *child, pid_t from, pid_t to) {
+    (void)child;
+    (void)from;
+    (void)to;
+}
+
+void copy_user(struct ptrace_child *d, struct ptrace_child *s) {
+    (void)d;
+    (void)s;
+}
+
+#endif

--- a/platform/darwin/darwin.h
+++ b/platform/darwin/darwin.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2026 by reptyr contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef DARWIN_H
+#define DARWIN_H
+
+#ifdef __APPLE__
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <termios.h>
+#include <unistd.h>
+
+#define do_socketcall(child, scratch, name, a0, a1, a2, a3, a4) (ENOTSUP * -1)
+
+int darwin_attach_child(pid_t pid, const char *pty, int force_stdio);
+
+#endif
+#endif

--- a/platform/darwin/darwin_attach.c
+++ b/platform/darwin/darwin_attach.c
@@ -479,9 +479,9 @@ out:
         }
     }
 
-    if (remote_pty)
+    if (remote_pty && can_deallocate_payload)
         mach_vm_deallocate(task, remote_pty, remote_pty_size);
-    if (result_addr)
+    if (result_addr && can_deallocate_payload)
         mach_vm_deallocate(task, result_addr, result_size);
     if (code && can_deallocate_payload)
         mach_vm_deallocate(task, code, code_size);

--- a/platform/darwin/darwin_attach.c
+++ b/platform/darwin/darwin_attach.c
@@ -1,0 +1,528 @@
+/*
+ * Copyright (C) 2026 by reptyr contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifdef __APPLE__
+
+#include "darwin.h"
+#include "../platform.h"
+#include "../../reptyr.h"
+
+#include <libproc.h>
+#include <mach/mach.h>
+#include <mach/mach_vm.h>
+#include <stdint.h>
+#include <sys/proc_info.h>
+#include <sys/syscall.h>
+#include <sys/sysctl.h>
+#include <sys/vnode.h>
+
+#ifndef NODEV
+#define NODEV ((dev_t)-1)
+#endif
+
+#define DARWIN_PAYLOAD_TIMEOUT_MS 2000
+#define DARWIN_MAX_REDIRECT_FDS 64
+
+#if defined(__arm64__)
+static uint32_t movz64(unsigned reg, uint16_t imm, unsigned shift) {
+    return 0xd2800000u | ((shift / 16) << 21) | ((uint32_t)imm << 5) | reg;
+}
+
+static uint32_t movk64(unsigned reg, uint16_t imm, unsigned shift) {
+    return 0xf2800000u | ((shift / 16) << 21) | ((uint32_t)imm << 5) | reg;
+}
+
+static uint32_t movz32(unsigned reg, uint16_t imm, unsigned shift) {
+    return 0x52800000u | ((shift / 16) << 21) | ((uint32_t)imm << 5) | reg;
+}
+
+static size_t emit_mov64(uint32_t *out, unsigned reg, uint64_t value) {
+    out[0] = movz64(reg, (uint16_t)(value & 0xffff), 0);
+    out[1] = movk64(reg, (uint16_t)((value >> 16) & 0xffff), 16);
+    out[2] = movk64(reg, (uint16_t)((value >> 32) & 0xffff), 32);
+    out[3] = movk64(reg, (uint16_t)((value >> 48) & 0xffff), 48);
+    return 4;
+}
+#endif
+
+struct remote_result {
+    uint64_t result;
+    uint32_t done;
+    uint32_t step;
+};
+
+#if defined(__arm64__)
+
+static int task_for_pid_errno(pid_t pid, task_t *task) {
+    kern_return_t kr = task_for_pid(mach_task_self(), pid, task);
+    if (kr == KERN_SUCCESS)
+        return 0;
+    error("task_for_pid(%d) failed: %s (%d). On macOS, the target usually needs get-task-allow entitlement or Developer Mode/debug permission.",
+          pid, mach_error_string(kr), kr);
+    return EPERM;
+}
+
+static void deallocate_thread_list(thread_act_array_t threads, mach_msg_type_number_t thread_count) {
+    mach_msg_type_number_t i;
+
+    if (!threads)
+        return;
+    for (i = 0; i < thread_count; i++) {
+        if (threads[i] != MACH_PORT_NULL)
+            mach_port_deallocate(mach_task_self(), threads[i]);
+    }
+    vm_deallocate(mach_task_self(), (vm_address_t)threads, thread_count * sizeof(thread_t));
+}
+
+static int read_target_ctty(pid_t pid, dev_t *ctty) {
+    struct kinfo_proc kp;
+    size_t len = sizeof(kp);
+    int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, pid };
+
+    if (sysctl(mib, 4, &kp, &len, NULL, 0) < 0) {
+        error("sysctl(KERN_PROC_PID, %d) failed: %s", pid, strerror(errno));
+        return assert_nonzero(errno);
+    }
+    if (len == 0)
+        return ESRCH;
+
+    *ctty = kp.kp_eproc.e_tdev;
+    return 0;
+}
+
+static int darwin_find_tty_fds(pid_t pid, int **out_fds, int *out_count) {
+    struct fd_array tty_fds = {};
+    struct proc_fdinfo *fds = NULL;
+    int buffer_size;
+    int actual_size;
+    int fd_count;
+    int attempts;
+    dev_t ctty;
+    int err;
+    int i;
+
+    *out_fds = NULL;
+    *out_count = 0;
+
+    err = read_target_ctty(pid, &ctty);
+    if (err)
+        return err;
+    if (ctty == NODEV) {
+        error("Target is not connected to a terminal.\n"
+              "    Use -s to force attaching anyways.");
+        return ENOTTY;
+    }
+
+    for (attempts = 0; attempts < 3; attempts++) {
+        buffer_size = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, NULL, 0);
+        if (buffer_size <= 0) {
+            error("proc_pidinfo(PROC_PIDLISTFDS, %d) failed: %s", pid, strerror(errno));
+            return assert_nonzero(errno);
+        }
+
+        buffer_size += 8 * (int)PROC_PIDLISTFD_SIZE;
+        free(fds);
+        fds = malloc((size_t)buffer_size);
+        if (!fds)
+            return ENOMEM;
+
+        actual_size = proc_pidinfo(pid, PROC_PIDLISTFDS, 0, fds, buffer_size);
+        if (actual_size <= 0) {
+            err = assert_nonzero(errno);
+            error("proc_pidinfo(PROC_PIDLISTFDS, %d) failed: %s", pid, strerror(errno));
+            goto out;
+        }
+        if (actual_size < buffer_size)
+            break;
+    }
+
+    fd_count = actual_size / (int)sizeof(fds[0]);
+    debug("Looking up fds for Darwin controlling tty %llu in child %d.",
+          (unsigned long long)ctty, pid);
+
+    for (i = 0; i < fd_count; i++) {
+        struct vnode_fdinfowithpath vnode_info;
+        dev_t rdev;
+        int got;
+
+        if (fds[i].proc_fd < 0 || fds[i].proc_fdtype != PROX_FDTYPE_VNODE)
+            continue;
+
+        got = proc_pidfdinfo(pid, fds[i].proc_fd, PROC_PIDFDVNODEPATHINFO,
+                             &vnode_info, sizeof(vnode_info));
+        if (got != sizeof(vnode_info)) {
+            debug("Skipping fd %d: PROC_PIDFDVNODEPATHINFO failed: %s",
+                  fds[i].proc_fd, strerror(errno));
+            continue;
+        }
+
+        if (vnode_info.pvip.vip_vi.vi_type != VCHR)
+            continue;
+
+        rdev = vnode_info.pvip.vip_vi.vi_stat.vst_rdev;
+        if (rdev != ctty)
+            continue;
+
+        debug("Found an alias for the tty: fd %d (%s)",
+              fds[i].proc_fd, vnode_info.pvip.vip_path);
+        if (fd_array_push(&tty_fds, fds[i].proc_fd) != 0) {
+            err = ENOMEM;
+            error("Unable to allocate memory for fd array.");
+            goto out;
+        }
+    }
+
+    if (tty_fds.n == 0) {
+        error("Target has a controlling terminal, but no open fd aliases were found.\n"
+              "    Use -s to force attaching stdio fds 0-2.");
+        err = ENOTTY;
+        goto out;
+    }
+
+    *out_fds = tty_fds.fds;
+    *out_count = tty_fds.n;
+    tty_fds.fds = NULL;
+    err = 0;
+
+out:
+    free(tty_fds.fds);
+    free(fds);
+    return err;
+}
+
+#define ARM64_COND_CS 2u
+#define DARWIN_PAYLOAD_STEP_OPEN 1u
+#define DARWIN_PAYLOAD_STEP_DUP2_BASE 100u
+#define DARWIN_PAYLOAD_STEP_CLOSE 200u
+
+static void patch_cond_branch(uint32_t *insns, size_t branch_at, size_t target, unsigned cond) {
+    int64_t offset = (int64_t)target - (int64_t)branch_at;
+    insns[branch_at] = 0x54000000u | (((uint32_t)offset & 0x7ffffu) << 5) | (cond & 0xfu);
+}
+
+static size_t emit_syscall_error_branch(uint32_t *insns, size_t *n, unsigned step) {
+    size_t branch_at;
+
+    insns[(*n)++] = movz32(21, (uint16_t)step, 0); /* mov w21, step */
+    insns[(*n)++] = 0xd4001001u; /* svc #0x80 */
+    branch_at = (*n)++;
+    return branch_at;
+}
+
+static void emit_success_report(uint32_t *insns, size_t *n, mach_vm_address_t result_addr) {
+    *n += emit_mov64(&insns[*n], 1, result_addr);
+    *n += emit_mov64(&insns[*n], 0, 0);          /* result = 0 */
+    insns[(*n)++] = 0xf9000020u;                 /* str x0, [x1] */
+    insns[(*n)++] = movz32(2, 1, 0);             /* done = success */
+    insns[(*n)++] = 0xb9000822u;                 /* str w2, [x1, #8] */
+    insns[(*n)++] = movz32(2, 0, 0);             /* step = 0 */
+    insns[(*n)++] = 0xb9000c22u;                 /* str w2, [x1, #12] */
+    insns[(*n)++] = 0xd503205fu;                 /* wfe */
+    insns[(*n)++] = 0x17ffffffu;                 /* b .-4 */
+}
+
+static void emit_error_report(uint32_t *insns, size_t *n, mach_vm_address_t result_addr) {
+    *n += emit_mov64(&insns[*n], 1, result_addr);
+    insns[(*n)++] = 0xf9000020u;                 /* str x0, [x1] */
+    insns[(*n)++] = movz32(2, 2, 0);             /* done = error */
+    insns[(*n)++] = 0xb9000822u;                 /* str w2, [x1, #8] */
+    insns[(*n)++] = 0xb9000c35u;                 /* str w21, [x1, #12] */
+    insns[(*n)++] = 0xd503205fu;                 /* wfe */
+    insns[(*n)++] = 0x17ffffffu;                 /* b .-4 */
+}
+static int darwin_redirect_fds(task_t task, const char *pty, const int *target_fds, int target_fd_count) {
+    mach_vm_address_t remote_pty = 0;
+    mach_vm_size_t remote_pty_size = strlen(pty) + 1;
+    mach_vm_address_t result_addr = 0;
+    mach_vm_size_t result_size = 4096;
+    mach_vm_address_t code = 0;
+    mach_vm_size_t code_size = 4096;
+    mach_vm_address_t stack = 0;
+    mach_vm_size_t stack_size = 64 * 1024;
+    thread_act_array_t threads = NULL;
+    mach_msg_type_number_t thread_count = 0;
+    char *suspended = NULL;
+    thread_act_t thread = MACH_PORT_NULL;
+    kern_return_t kr;
+    struct remote_result result = {0};
+    uint32_t insns[64 + DARWIN_MAX_REDIRECT_FDS * 12];
+    size_t error_branches[2 + DARWIN_MAX_REDIRECT_FDS];
+    size_t n = 0;
+    size_t error_label;
+    arm_thread_state64_t saved_state;
+    arm_thread_state64_t state;
+    mach_msg_type_number_t state_count;
+    int err = 0;
+    int thread_running_payload = 0;
+    int state_saved = 0;
+    int can_deallocate_payload = 1;
+    int i;
+
+    if (target_fd_count <= 0)
+        return EINVAL;
+    if (target_fd_count > DARWIN_MAX_REDIRECT_FDS) {
+        error("Refusing to redirect %d fds; built-in safety cap is %d.",
+              target_fd_count, DARWIN_MAX_REDIRECT_FDS);
+        return E2BIG;
+    }
+
+    kr = mach_vm_allocate(task, &remote_pty, remote_pty_size, VM_FLAGS_ANYWHERE);
+    if (kr != KERN_SUCCESS) {
+        error("mach_vm_allocate(pty) failed: %s (%d)", mach_error_string(kr), kr);
+        err = EIO;
+        goto out;
+    }
+    kr = mach_vm_write(task, remote_pty, (vm_offset_t)pty, (mach_msg_type_number_t)remote_pty_size);
+    if (kr != KERN_SUCCESS) {
+        error("mach_vm_write(pty) failed: %s (%d)", mach_error_string(kr), kr);
+        err = EIO;
+        goto out;
+    }
+
+    kr = mach_vm_allocate(task, &result_addr, result_size, VM_FLAGS_ANYWHERE);
+    if (kr != KERN_SUCCESS) {
+        error("mach_vm_allocate(result) failed: %s (%d)", mach_error_string(kr), kr);
+        err = EIO;
+        goto out;
+    }
+    kr = mach_vm_write(task, result_addr, (vm_offset_t)&result, sizeof(result));
+    if (kr != KERN_SUCCESS) {
+        error("mach_vm_write(result) failed: %s (%d)", mach_error_string(kr), kr);
+        err = EIO;
+        goto out;
+    }
+
+    /* fd = open(remote_pty, O_RDWR | O_NOCTTY); */
+    n += emit_mov64(&insns[n], 0, remote_pty);
+    n += emit_mov64(&insns[n], 1, O_RDWR | O_NOCTTY);
+    n += emit_mov64(&insns[n], 16, SYS_open);
+    error_branches[0] = emit_syscall_error_branch(insns, &n, DARWIN_PAYLOAD_STEP_OPEN);
+    insns[n++] = 0xaa0003f4u; /* mov x20, x0 */
+
+    for (i = 0; i < target_fd_count; i++) {
+        /* dup2(x20, target_fds[i]); */
+        insns[n++] = 0xaa1403e0u; /* mov x0, x20 */
+        n += emit_mov64(&insns[n], 1, (uint64_t)target_fds[i]);
+        n += emit_mov64(&insns[n], 16, SYS_dup2);
+        error_branches[1 + i] = emit_syscall_error_branch(insns, &n, DARWIN_PAYLOAD_STEP_DUP2_BASE + (unsigned)i);
+    }
+
+    /* close(x20); */
+    insns[n++] = 0xaa1403e0u; /* mov x0, x20 */
+    n += emit_mov64(&insns[n], 16, SYS_close);
+    error_branches[1 + target_fd_count] = emit_syscall_error_branch(insns, &n, DARWIN_PAYLOAD_STEP_CLOSE);
+
+    emit_success_report(insns, &n, result_addr);
+    error_label = n;
+    emit_error_report(insns, &n, result_addr);
+
+    for (i = 0; i < target_fd_count + 2; i++)
+        patch_cond_branch(insns, error_branches[i], error_label, ARM64_COND_CS);
+
+    kr = mach_vm_allocate(task, &code, code_size, VM_FLAGS_ANYWHERE);
+    if (kr != KERN_SUCCESS) {
+        error("mach_vm_allocate(code) failed: %s (%d)", mach_error_string(kr), kr);
+        err = EIO;
+        goto out;
+    }
+    kr = mach_vm_write(task, code, (vm_offset_t)insns, (mach_msg_type_number_t)(n * sizeof(insns[0])));
+    if (kr != KERN_SUCCESS) {
+        error("mach_vm_write(code) failed: %s (%d)", mach_error_string(kr), kr);
+        err = EIO;
+        goto out;
+    }
+    kr = mach_vm_protect(task, code, code_size, FALSE, VM_PROT_READ | VM_PROT_EXECUTE);
+    if (kr != KERN_SUCCESS) {
+        error("mach_vm_protect(code RX) failed: %s (%d)", mach_error_string(kr), kr);
+        err = EACCES;
+        goto out;
+    }
+
+    kr = mach_vm_allocate(task, &stack, stack_size, VM_FLAGS_ANYWHERE);
+    if (kr != KERN_SUCCESS) {
+        error("mach_vm_allocate(stack) failed: %s (%d)", mach_error_string(kr), kr);
+        err = EIO;
+        goto out;
+    }
+
+    kr = task_threads(task, &threads, &thread_count);
+    if (kr != KERN_SUCCESS || thread_count == 0) {
+        error("task_threads failed: %s (%d), count=%u", mach_error_string(kr), kr, thread_count);
+        err = EIO;
+        goto out;
+    }
+
+    suspended = calloc(thread_count, sizeof(*suspended));
+    if (!suspended) {
+        err = ENOMEM;
+        goto out;
+    }
+
+    for (i = 0; i < (int)thread_count; i++) {
+        kr = thread_suspend(threads[i]);
+        if (kr != KERN_SUCCESS) {
+            error("thread_suspend failed: %s (%d)", mach_error_string(kr), kr);
+            err = EIO;
+            goto out;
+        }
+        suspended[i] = 1;
+    }
+    thread = threads[0];
+    thread_abort(thread);
+
+    state_count = ARM_THREAD_STATE64_COUNT;
+    kr = thread_get_state(thread, ARM_THREAD_STATE64, (thread_state_t)&saved_state, &state_count);
+    if (kr != KERN_SUCCESS) {
+        error("thread_get_state failed: %s (%d)", mach_error_string(kr), kr);
+        err = EIO;
+        goto out;
+    }
+    state_saved = 1;
+
+    memset(&state, 0, sizeof(state));
+    state.__pc = code;
+    state.__sp = (stack + stack_size - 16) & ~((mach_vm_address_t)0xf);
+    kr = thread_set_state(thread, ARM_THREAD_STATE64, (thread_state_t)&state, ARM_THREAD_STATE64_COUNT);
+    if (kr != KERN_SUCCESS) {
+        error("thread_set_state failed: %s (%d)", mach_error_string(kr), kr);
+        err = EACCES;
+        goto out;
+    }
+
+    kr = thread_resume(thread);
+    if (kr != KERN_SUCCESS) {
+        error("thread_resume failed: %s (%d)", mach_error_string(kr), kr);
+        err = EIO;
+        goto out;
+    }
+    suspended[0] = 0;
+    thread_running_payload = 1;
+
+    for (i = 0; i < DARWIN_PAYLOAD_TIMEOUT_MS / 10; i++) {
+        mach_vm_size_t out_size = 0;
+        kr = mach_vm_read_overwrite(task, result_addr, sizeof(result), (mach_vm_address_t)&result, &out_size);
+        if (kr != KERN_SUCCESS) {
+            error("mach_vm_read_overwrite(result) failed: %s (%d)", mach_error_string(kr), kr);
+            err = EIO;
+            goto out;
+        }
+        if (result.done == 1) {
+            debug("Darwin fd redirect payload completed");
+            err = 0;
+            goto out;
+        }
+        if (result.done == 2) {
+            err = result.result > 0 && result.result < 4096 ? (int)result.result : EIO;
+            error("Darwin fd redirect payload syscall step %u failed: %s",
+                  result.step, strerror(err));
+            goto out;
+        }
+        usleep(10000);
+    }
+
+    error("Darwin fd redirect payload timed out");
+    err = ETIMEDOUT;
+
+out:
+    if (thread != MACH_PORT_NULL && thread_running_payload) {
+        kr = thread_suspend(thread);
+        if (kr == KERN_SUCCESS) {
+            thread_running_payload = 0;
+            if (state_saved)
+                thread_set_state(thread, ARM_THREAD_STATE64, (thread_state_t)&saved_state, ARM_THREAD_STATE64_COUNT);
+            thread_abort(thread);
+            thread_resume(thread);
+        } else {
+            error("thread_suspend during cleanup failed: %s (%d)", mach_error_string(kr), kr);
+            can_deallocate_payload = 0;
+        }
+    } else if (thread != MACH_PORT_NULL && state_saved) {
+        thread_set_state(thread, ARM_THREAD_STATE64, (thread_state_t)&saved_state, ARM_THREAD_STATE64_COUNT);
+        thread_abort(thread);
+    }
+
+    if (suspended) {
+        for (i = 0; i < (int)thread_count; i++) {
+            if (suspended[i])
+                thread_resume(threads[i]);
+        }
+    }
+
+    if (remote_pty)
+        mach_vm_deallocate(task, remote_pty, remote_pty_size);
+    if (result_addr)
+        mach_vm_deallocate(task, result_addr, result_size);
+    if (code && can_deallocate_payload)
+        mach_vm_deallocate(task, code, code_size);
+    if (stack && can_deallocate_payload)
+        mach_vm_deallocate(task, stack, stack_size);
+    free(suspended);
+    deallocate_thread_list(threads, thread_count);
+    return err;
+}
+
+#endif
+
+int darwin_attach_child(pid_t pid, const char *pty, int force_stdio) {
+#if !defined(__arm64__)
+    (void)pid;
+    (void)pty;
+    (void)force_stdio;
+    error("macOS attach is currently implemented only for arm64 targets.");
+    return ENOTSUP;
+#else
+    task_t task = MACH_PORT_NULL;
+    int stdio_fds[] = {0, 1, 2};
+    int *target_fds = NULL;
+    int target_fd_count = 0;
+    int err;
+
+    if (force_stdio) {
+        target_fds = stdio_fds;
+        target_fd_count = 3;
+    } else {
+        err = darwin_find_tty_fds(pid, &target_fds, &target_fd_count);
+        if (err)
+            return err;
+    }
+
+    err = task_for_pid_errno(pid, &task);
+    if (err)
+        goto out;
+
+    debug("Using tty: %s", pty);
+    err = darwin_redirect_fds(task, pty, target_fds, target_fd_count);
+    if (err)
+        goto out;
+
+    kill(pid, SIGWINCH);
+
+out:
+    if (task != MACH_PORT_NULL)
+        mach_port_deallocate(mach_task_self(), task);
+    if (!force_stdio)
+        free(target_fds);
+    return err;
+#endif
+}
+
+#endif

--- a/platform/darwin/darwin_attach.c
+++ b/platform/darwin/darwin_attach.c
@@ -209,6 +209,7 @@ out:
     return err;
 }
 
+#define ARM64_COND_EQ 0u
 #define ARM64_COND_CS 2u
 #define DARWIN_PAYLOAD_STEP_OPEN 1u
 #define DARWIN_PAYLOAD_STEP_DUP2_BASE 100u
@@ -255,7 +256,7 @@ static int darwin_redirect_fds(task_t task, const char *pty, const int *target_f
     mach_vm_address_t result_addr = 0;
     mach_vm_size_t result_size = 4096;
     mach_vm_address_t code = 0;
-    mach_vm_size_t code_size = 4096;
+    mach_vm_size_t code_size = 8192;
     mach_vm_address_t stack = 0;
     mach_vm_size_t stack_size = 64 * 1024;
     thread_act_array_t threads = NULL;
@@ -264,8 +265,9 @@ static int darwin_redirect_fds(task_t task, const char *pty, const int *target_f
     thread_act_t thread = MACH_PORT_NULL;
     kern_return_t kr;
     struct remote_result result = {0};
-    uint32_t insns[64 + DARWIN_MAX_REDIRECT_FDS * 12];
+    uint32_t insns[64 + DARWIN_MAX_REDIRECT_FDS * 18];
     size_t error_branches[2 + DARWIN_MAX_REDIRECT_FDS];
+    size_t skip_close_branches[DARWIN_MAX_REDIRECT_FDS];
     size_t n = 0;
     size_t error_label;
     arm_thread_state64_t saved_state;
@@ -326,10 +328,20 @@ static int darwin_redirect_fds(task_t task, const char *pty, const int *target_f
         error_branches[1 + i] = emit_syscall_error_branch(insns, &n, DARWIN_PAYLOAD_STEP_DUP2_BASE + (unsigned)i);
     }
 
+    for (i = 0; i < target_fd_count; i++) {
+        /* If open() reused a closed target fd, closing x20 would undo the redirect. */
+        n += emit_mov64(&insns[n], 21, (uint64_t)target_fds[i]);
+        insns[n++] = 0xeb15029fu; /* cmp x20, x21 */
+        skip_close_branches[i] = n++;
+    }
+
     /* close(x20); */
     insns[n++] = 0xaa1403e0u; /* mov x0, x20 */
     n += emit_mov64(&insns[n], 16, SYS_close);
     error_branches[1 + target_fd_count] = emit_syscall_error_branch(insns, &n, DARWIN_PAYLOAD_STEP_CLOSE);
+
+    for (i = 0; i < target_fd_count; i++)
+        patch_cond_branch(insns, skip_close_branches[i], n, ARM64_COND_EQ);
 
     emit_success_report(insns, &n, result_addr);
     error_label = n;

--- a/platform/darwin/darwin_ptrace.c
+++ b/platform/darwin/darwin_ptrace.c
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2026 by reptyr contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifdef __APPLE__
+
+#include <errno.h>
+#include <string.h>
+
+#include "../../ptrace.h"
+
+static int unsupported(struct ptrace_child *child) {
+    if (child)
+        child->error = ENOTSUP;
+    return -1;
+}
+
+struct syscall_numbers *ptrace_syscall_numbers(struct ptrace_child *child) {
+    static struct syscall_numbers unsupported_syscalls = {
+        .nr_mmap = -1,
+        .nr_mmap2 = -1,
+        .nr_munmap = -1,
+        .nr_getsid = -1,
+        .nr_setsid = -1,
+        .nr_setpgid = -1,
+        .nr_fork = -1,
+        .nr_clone = -1,
+        .nr_wait4 = -1,
+        .nr_signal = -1,
+        .nr_rt_sigaction = -1,
+        .nr_openat = -1,
+        .nr_close = -1,
+        .nr_ioctl = -1,
+        .nr_dup2 = -1,
+        .nr_dup3 = -1,
+        .nr_socket = -1,
+        .nr_connect = -1,
+        .nr_sendmsg = -1,
+        .nr_socketcall = -1,
+    };
+    (void)child;
+    return &unsupported_syscalls;
+}
+
+int ptrace_wait(struct ptrace_child *child) {
+    return unsupported(child);
+}
+
+int ptrace_attach_child(struct ptrace_child *child, pid_t pid) {
+    memset(child, 0, sizeof(*child));
+    child->pid = pid;
+    child->state = ptrace_detached;
+    child->error = ENOTSUP;
+    return -1;
+}
+
+int ptrace_finish_attach(struct ptrace_child *child, pid_t pid) {
+    memset(child, 0, sizeof(*child));
+    child->pid = pid;
+    child->state = ptrace_detached;
+    child->error = ENOTSUP;
+    return -1;
+}
+
+int ptrace_detach_child(struct ptrace_child *child) {
+    if (child)
+        child->state = ptrace_detached;
+    return 0;
+}
+
+int ptrace_advance_to_state(struct ptrace_child *child, enum child_state desired) {
+    (void)desired;
+    return unsupported(child);
+}
+
+int ptrace_save_regs(struct ptrace_child *child) {
+    return unsupported(child);
+}
+
+int ptrace_restore_regs(struct ptrace_child *child) {
+    return unsupported(child);
+}
+
+unsigned long ptrace_remote_syscall(struct ptrace_child *child,
+                                    unsigned long sysno,
+                                    unsigned long p0, unsigned long p1,
+                                    unsigned long p2, unsigned long p3,
+                                    unsigned long p4, unsigned long p5) {
+    (void)sysno;
+    (void)p0;
+    (void)p1;
+    (void)p2;
+    (void)p3;
+    (void)p4;
+    (void)p5;
+    unsupported(child);
+    return (unsigned long)-ENOTSUP;
+}
+
+int ptrace_memcpy_to_child(struct ptrace_child *child, child_addr_t dst, const void *src, size_t n) {
+    (void)dst;
+    (void)src;
+    (void)n;
+    return unsupported(child);
+}
+
+int ptrace_memcpy_from_child(struct ptrace_child *child, void *dst, child_addr_t src, size_t n) {
+    (void)dst;
+    (void)src;
+    (void)n;
+    return unsupported(child);
+}
+
+#endif

--- a/platform/platform.h
+++ b/platform/platform.h
@@ -23,12 +23,9 @@
 #ifndef PLATFORM_H
 #define PLATFORM_H
 
-#ifdef __APPLE__
-#error "reptyr does not currently support macOS"
-#endif
-
 #include "linux/linux.h"
 #include "freebsd/freebsd.h"
+#include "darwin/darwin.h"
 #include "../ptrace.h"
 
 struct fd_array {

--- a/reptyr.c
+++ b/reptyr.c
@@ -74,16 +74,17 @@ void error(const char *msg, ...) {
     va_end(ap);
 }
 
-void setup_raw(struct termios *save) {
+int setup_raw(struct termios *save) {
     struct termios set;
     if (tcgetattr(0, save) < 0) {
-        fprintf(stderr, "Unable to read terminal attributes: %m");
-        return;
+        fprintf(stderr, "Unable to read terminal attributes: %s\n", strerror(errno));
+        return 0;
     }
     set = *save;
     cfmakeraw(&set);
     if (tcsetattr(0, TCSANOW, &set) < 0)
-        die("Unable to set terminal attributes: %m");
+        die("Unable to set terminal attributes: %s", strerror(errno));
+    return 1;
 }
 
 void resize_pty(int pty) {
@@ -133,7 +134,7 @@ void do_proxy(int pty) {
     sigemptyset(&mask);
     sigaddset(&mask, SIGWINCH);
     if (sigprocmask(SIG_BLOCK, &mask, NULL) == -1) {
-        fprintf(stderr, "sigprocmask: %m");
+        fprintf(stderr, "sigprocmask: %s", strerror(errno));
         return;
     }
     sa.sa_handler = do_winch;
@@ -154,7 +155,7 @@ void do_proxy(int pty) {
         if (pselect(pty + 1, &set, NULL, NULL, NULL, &select_mask) < 0) {
             if (errno == EINTR)
                 continue;
-            fprintf(stderr, "select: %m");
+            fprintf(stderr, "select: %s", strerror(errno));
             return;
         }
         if (FD_ISSET(0, &set)) {
@@ -197,6 +198,7 @@ int main(int argc, char **argv) {
     int force_stdio = 0;
     int do_steal = 0;
     int unattached_script_redirection = 0;
+    int restore_termios = 0;
 
     while ((opt = getopt(argc, argv, "hlLsTvV")) != -1) {
         switch (opt) {
@@ -239,11 +241,11 @@ int main(int argc, char **argv) {
 
     if (!do_steal) {
         if ((pty = get_pt()) < 0)
-            die("Unable to allocate a new pseudo-terminal: %m");
+            die("Unable to allocate a new pseudo-terminal: %s", strerror(errno));
         if (unlockpt(pty) < 0)
-            die("Unable to unlockpt: %m");
+            die("Unable to unlockpt: %s", strerror(errno));
         if (grantpt(pty) < 0)
-            die("Unable to grantpt: %m");
+            die("Unable to grantpt: %s", strerror(errno));
     }
 
     if (do_attach) {
@@ -251,7 +253,7 @@ int main(int argc, char **argv) {
         errno = 0;
         long t = strtol(argv[optind], &endptr, 10);
         if (errno == ERANGE)
-            die("Invalid pid: %m");
+            die("Invalid pid: %s", strerror(errno));
         if (*endptr)
             die("Invalid pid: must be integer");
         /* check for overflow/underflow */
@@ -266,7 +268,11 @@ int main(int argc, char **argv) {
         }
         if (err) {
             fprintf(stderr, "Unable to attach to pid %d: %s\n", child, strerror(err));
-            if (err == EPERM) {
+            if (err == EPERM
+#ifdef __APPLE__
+                || err == ENOTSUP
+#endif
+            ) {
                 check_ptrace_scope();
             }
             return 1;
@@ -296,13 +302,15 @@ int main(int argc, char **argv) {
         }
     }
 
-    setup_raw(&saved_termios);
+    restore_termios = setup_raw(&saved_termios);
     do_proxy(pty);
-    do {
-        errno = 0;
-        if (tcsetattr(0, TCSANOW, &saved_termios) && errno != EINTR)
-            die("Unable to tcsetattr: %m");
-    } while (errno == EINTR);
+    if (restore_termios) {
+        do {
+            errno = 0;
+            if (tcsetattr(0, TCSANOW, &saved_termios) && errno != EINTR)
+                die("Unable to tcsetattr: %s", strerror(errno));
+        } while (errno == EINTR);
+    }
 
     return 0;
 }

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,3 +1,5 @@
 victim.o
 victim
+darwin-victim.o
+darwin-victim
 *.pyc

--- a/test/darwin-basic.py
+++ b/test/darwin-basic.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+import os
+import pty
+import select
+import signal
+import subprocess
+import sys
+import time
+
+
+PROCS = []
+
+
+class ForkedProc:
+    def __init__(self, pid):
+        self.pid = pid
+        self.returncode = None
+
+    def poll(self):
+        if self.returncode is not None:
+            return self.returncode
+        try:
+            pid, status = os.waitpid(self.pid, os.WNOHANG)
+        except ChildProcessError:
+            self.returncode = 0
+            return self.returncode
+        if pid == 0:
+            return None
+        if os.WIFEXITED(status):
+            self.returncode = os.WEXITSTATUS(status)
+        elif os.WIFSIGNALED(status):
+            self.returncode = -os.WTERMSIG(status)
+        else:
+            self.returncode = status
+        return self.returncode
+
+    def terminate(self):
+        if self.poll() is None:
+            os.kill(self.pid, signal.SIGTERM)
+
+    def kill(self):
+        if self.poll() is None:
+            os.kill(self.pid, signal.SIGKILL)
+
+    def wait(self, timeout=None):
+        deadline = None if timeout is None else time.time() + timeout
+        while self.poll() is None:
+            if deadline is not None and time.time() > deadline:
+                raise subprocess.TimeoutExpired(["pid", str(self.pid)], timeout or 0)
+            time.sleep(0.05)
+        return self.returncode
+
+
+def codesign_for_task_for_pid(*paths):
+    entitlements = "test/darwin-debug.entitlements"
+    for path in paths:
+        subprocess.check_call([
+            "codesign",
+            "-s",
+            "-",
+            "--force",
+            "--entitlements",
+            entitlements,
+            path,
+        ])
+
+
+def read_until(fd, needle, timeout=5):
+    deadline = time.time() + timeout
+    data = b""
+    while time.time() < deadline:
+        r, _, _ = select.select([fd], [], [], 0.1)
+        if fd not in r:
+            continue
+        chunk = os.read(fd, 4096)
+        if not chunk:
+            break
+        data += chunk
+        sys.stdout.buffer.write(chunk)
+        sys.stdout.buffer.flush()
+        if needle in data:
+            return data
+    raise AssertionError("timed out waiting for %r; got %r" % (needle, data))
+
+
+def spawn_on_controlling_pty(argv):
+    pid, master = pty.fork()
+    if pid == 0:
+        os.execvp(argv[0], argv)
+    proc = ForkedProc(pid)
+    PROCS.append(proc)
+    return proc, master
+
+
+def stop_process(proc):
+    if proc and proc.poll() is None:
+        proc.terminate()
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def exercise_attach(reptyr_args, initial_word, attached_word):
+    child, child_fd = spawn_on_controlling_pty(["test/darwin-victim"])
+    try:
+        os.write(child_fd, (initial_word + "\n").encode("ascii"))
+        read_until(child_fd, ("ECHO: " + initial_word).encode("ascii"))
+
+        reptyr, reptyr_fd = spawn_on_controlling_pty(["./reptyr", "-V"] + reptyr_args + [str(child.pid)])
+        read_until(reptyr_fd, b"Darwin fd redirect payload completed")
+        os.write(reptyr_fd, (attached_word + "\n").encode("ascii"))
+        read_until(reptyr_fd, ("ECHO: " + attached_word).encode("ascii"))
+        stop_process(reptyr)
+    finally:
+        stop_process(child)
+
+
+try:
+    codesign_for_task_for_pid("./reptyr", "test/darwin-victim")
+    exercise_attach(["-s"], "hello", "world")
+    exercise_attach([], "plain", "attach")
+finally:
+    for proc in reversed(PROCS):
+        stop_process(proc)

--- a/test/darwin-basic.py
+++ b/test/darwin-basic.py
@@ -83,9 +83,11 @@ def read_until(fd, needle, timeout=5):
     raise AssertionError("timed out waiting for %r; got %r" % (needle, data))
 
 
-def spawn_on_controlling_pty(argv):
+def spawn_on_controlling_pty(argv, env=None):
     pid, master = pty.fork()
     if pid == 0:
+        if env:
+            os.environ.update(env)
         os.execvp(argv[0], argv)
     proc = ForkedProc(pid)
     PROCS.append(proc)
@@ -101,11 +103,14 @@ def stop_process(proc):
             proc.kill()
 
 
-def exercise_attach(reptyr_args, initial_word, attached_word):
-    child, child_fd = spawn_on_controlling_pty(["test/darwin-victim"])
+def exercise_attach(reptyr_args, initial_word, attached_word, child_env=None):
+    child, child_fd = spawn_on_controlling_pty(["test/darwin-victim"], child_env)
     try:
-        os.write(child_fd, (initial_word + "\n").encode("ascii"))
-        read_until(child_fd, ("ECHO: " + initial_word).encode("ascii"))
+        if initial_word is not None:
+            os.write(child_fd, (initial_word + "\n").encode("ascii"))
+            read_until(child_fd, ("ECHO: " + initial_word).encode("ascii"))
+        else:
+            read_until(child_fd, b"READY")
 
         reptyr, reptyr_fd = spawn_on_controlling_pty(["./reptyr", "-V"] + reptyr_args + [str(child.pid)])
         read_until(reptyr_fd, b"Darwin fd redirect payload completed")
@@ -119,6 +124,7 @@ def exercise_attach(reptyr_args, initial_word, attached_word):
 try:
     codesign_for_task_for_pid("./reptyr", "test/darwin-victim")
     exercise_attach(["-s"], "hello", "world")
+    exercise_attach(["-s"], None, "restored", {"DARWIN_VICTIM_CLOSE_STDIN": "1"})
     exercise_attach([], "plain", "attach")
 finally:
     for proc in reversed(PROCS):

--- a/test/darwin-debug.entitlements
+++ b/test/darwin-debug.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.get-task-allow</key>
+    <true/>
+</dict>
+</plist>

--- a/test/darwin-victim.c
+++ b/test/darwin-victim.c
@@ -1,0 +1,20 @@
+#include <errno.h>
+#include <stdio.h>
+#include <unistd.h>
+
+int main(void) {
+    char *line = NULL;
+    size_t cap = 0;
+
+    setvbuf(stdout, NULL, _IONBF, 0);
+
+    for (;;) {
+        errno = 0;
+        if (getline(&line, &cap, stdin) != -1) {
+            printf("ECHO: %s", line);
+            continue;
+        }
+        clearerr(stdin);
+        usleep(10000);
+    }
+}

--- a/test/darwin-victim.c
+++ b/test/darwin-victim.c
@@ -1,5 +1,6 @@
 #include <errno.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 
 int main(void) {
@@ -7,6 +8,11 @@ int main(void) {
     size_t cap = 0;
 
     setvbuf(stdout, NULL, _IONBF, 0);
+
+    if (getenv("DARWIN_VICTIM_CLOSE_STDIN")) {
+        close(STDIN_FILENO);
+        printf("READY\n");
+    }
 
     for (;;) {
         errno = 0;

--- a/test/list-pty.py
+++ b/test/list-pty.py
@@ -1,0 +1,26 @@
+from __future__ import print_function
+
+import subprocess
+import sys
+
+cmd = [
+    "./reptyr",
+    "-L",
+    "/bin/sh",
+    "-c",
+    "printf 'PTY=%s\\n' \"$REPTYR_PTY\"; test -c \"$REPTYR_PTY\"",
+]
+
+proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+output, _ = proc.communicate()
+if proc.returncode != 0:
+    sys.stdout.write(output.decode("utf-8", "replace"))
+    raise subprocess.CalledProcessError(proc.returncode, cmd, output)
+
+text = output.decode("utf-8", "replace")
+sys.stdout.write(text)
+
+line = next((line for line in text.splitlines() if line.startswith("PTY=")), None)
+assert line is not None, "reptyr -L did not print the child pty path"
+pty = line[4:]
+assert pty.startswith("/dev/"), "unexpected pty path: %r" % (pty,)


### PR DESCRIPTION
## Summary

This adds an experimental Darwin/macOS backend with enough support to build and exercise reptyr on macOS:

- add Darwin platform objects and platform stubs so the project builds on macOS
- support `reptyr -l` / `reptyr -L` on macOS
- add an arm64 Mach-based attach path for debug-attachable same-user targets
- support both `reptyr -s PID` and plain `reptyr PID`
  - `-s` redirects target fds 0/1/2
  - plain attach discovers open fds that alias the target's controlling tty using `sysctl(KERN_PROC_PID)` + `proc_pidinfo(PROC_PIDLISTFDS)` / `PROC_PIDFDVNODEPATHINFO`
- add Darwin smoke tests with ad-hoc signing for `task_for_pid()`
- update Cirrus from the EOL FreeBSD 12 image to FreeBSD 13.2 so the existing FreeBSD CI can start and install packages

The attach backend is deliberately scoped as experimental. It redirects matching fds to a new pty; it does not yet implement full Linux parity for controlling-terminal/session handoff (`setsid`, `TIOCNOTTY`, `TIOCSCTTY`, foreground pgrp, etc.). The README calls that out explicitly.

## Implementation notes

The Darwin attach path uses `task_for_pid()`, allocates a small remote payload, suspends the target's threads, runs one arm64 thread through an `open`/`dup2`/`close` syscall payload, restores the saved thread state, then resumes the target. The payload records syscall success/failure back to reptyr so attach failures do not silently corrupt target fds.

The Cirrus change is included because the previous `freebsd-12-4-release-amd64` task could no longer install packages (`pkgmir.geo.freebsd.org/FreeBSD:12:amd64/quarterly` returned 404). The updated FreeBSD 13 task passes on this PR.

## Test plan

Run locally on Apple Silicon macOS:

- `make test PYTHON_CMD=/usr/bin/python3`
- `make darwin-attach-test PYTHON_CMD=/usr/bin/python3`
- `make PYTHON_CMD=/usr/bin/python3 CFLAGS='-arch x86_64' LDFLAGS='-arch x86_64'`
- `git diff --check HEAD~1..HEAD`
- `/usr/bin/python3 -m py_compile test/list-pty.py test/darwin-basic.py`

Remote CI:

- Cirrus `freebsd_13`: passing

The Darwin attach test ad-hoc signs `./reptyr` and `test/darwin-victim` with `com.apple.security.get-task-allow` before exercising both `reptyr -s PID` and plain `reptyr PID`.
